### PR TITLE
给定DPI生成图片  渲染OFD页面为图片 ppm应是浮点型

### DIFF
--- a/ofdrw-converter/src/main/java/org/ofdrw/converter/AWTMaker.java
+++ b/ofdrw-converter/src/main/java/org/ofdrw/converter/AWTMaker.java
@@ -5,6 +5,7 @@ import org.apache.fontbox.ttf.TrueTypeFont;
 import org.apache.pdfbox.pdmodel.graphics.blend.BlendComposite;
 import org.apache.pdfbox.pdmodel.graphics.blend.BlendMode;
 import org.ofdrw.converter.point.Tuple2;
+import org.ofdrw.converter.utils.CommonUtil;
 import org.ofdrw.converter.utils.MatrixUtils;
 import org.ofdrw.core.annotation.pageannot.Annot;
 import org.ofdrw.core.annotation.pageannot.Appearance;
@@ -50,6 +51,7 @@ import java.util.Map;
  * AWT设备转换类
  *
  * @author qaqtutu
+ * @author iandjava
  * @since 2021-05-06 23:00:01
  */
 public abstract class AWTMaker {
@@ -62,9 +64,9 @@ public abstract class AWTMaker {
     /**
      * 每毫米像素数量(Pixels per millimeter)
      * <p>
-     * 默认为： 8像素/毫米
+     * 默认为： 200dpi->7.874015748031496
      */
-    protected int ppm = 8;
+    protected double ppm =CommonUtil.dpiToPixel(200);
 
     public final Config config = new Config();
 
@@ -94,7 +96,24 @@ public abstract class AWTMaker {
      * @param reader OFD解析器
      * @param ppm    每毫米像素数量(Pixels per millimeter)
      */
+    @Deprecated
     public AWTMaker(OFDReader reader, int ppm) {
+        this.reader = reader;
+        this.resourceManage = reader.getResMgt();
+        this.pages = reader.getPageList();
+        if (this.ppm > 0) {
+            this.ppm = ppm;
+        }
+    }
+    /**
+     * 创建图片转换对象实例
+     * <p>
+     * OFD内部使用毫米作为基本单位
+     *
+     * @param reader OFD解析器
+     * @param ppm    每毫米像素数量(Pixels per millimeter)
+     */
+    public AWTMaker(OFDReader reader,double ppm) {
         this.reader = reader;
         this.resourceManage = reader.getResMgt();
         this.pages = reader.getPageList();
@@ -153,8 +172,6 @@ public abstract class AWTMaker {
 
     /**
      * 印章混合模式
-     * 
-     * @return 复合对象
      */
     protected Composite getStampComposite() {
         // 正片叠底
@@ -558,7 +575,7 @@ public abstract class AWTMaker {
 
     private Matrix renderBoundaryAndSetClip(Graphics2D graphics, ST_Box boundary, Matrix parentMatrix) {
         graphics.setColor(Color.RED);
-        graphics.setStroke(new BasicStroke(0.1f * ppm));
+        graphics.setStroke(new BasicStroke(0.1f * (float)ppm));
         Matrix m = MatrixUtils.base().mtimes(parentMatrix);
         if (boundary != null) {
             /*
@@ -743,7 +760,7 @@ public abstract class AWTMaker {
         }
         return arr;
     }
-
+    
     public static class Config {
         /*
          * 印章透明度

--- a/ofdrw-converter/src/main/java/org/ofdrw/converter/AWTMaker.java
+++ b/ofdrw-converter/src/main/java/org/ofdrw/converter/AWTMaker.java
@@ -66,7 +66,7 @@ public abstract class AWTMaker {
      * <p>
      * 默认为： 200dpi->7.874015748031496
      */
-    protected double ppm =CommonUtil.dpiToPixel(200);
+    protected double ppm =CommonUtil.dpiToPpm(200);
 
     public final Config config = new Config();
 

--- a/ofdrw-converter/src/main/java/org/ofdrw/converter/ImageMaker.java
+++ b/ofdrw-converter/src/main/java/org/ofdrw/converter/ImageMaker.java
@@ -1,17 +1,18 @@
 package org.ofdrw.converter;
 
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+
 import org.ofdrw.core.basicType.ST_Box;
 import org.ofdrw.reader.OFDReader;
 import org.ofdrw.reader.PageInfo;
 import org.ofdrw.reader.tools.ImageUtils;
 
-import java.awt.*;
-import java.awt.image.BufferedImage;
-
 /**
  * 图片转换类
  *
  * @author qaqtutu
+ * @author iandjava
  * @since 2021-03-13 10:00:01
  */
 public class ImageMaker extends AWTMaker {
@@ -25,9 +26,22 @@ public class ImageMaker extends AWTMaker {
      * @param reader OFD解析器
      * @param ppm    每毫米像素数量(Pixels per millimeter)
      */
-
+	@Deprecated
     public ImageMaker(OFDReader reader, int ppm) {
         super(reader, ppm);
+    }
+    
+    /**
+     * 创建图片转换对象实例
+     * <p>
+     * OFD内部使用毫米作为基本单位
+     *
+     * @param reader OFD解析器
+     * @param ppm    每毫米像素数量(Pixels per millimeter) 调用CommonUtil.dpiToPixel(200) 给定DPI下的像素数量
+     */
+
+    public ImageMaker(OFDReader reader,double ppm) {
+        super(reader,ppm);
     }
 
     /**
@@ -42,10 +56,12 @@ public class ImageMaker extends AWTMaker {
         }
         PageInfo pageInfo = pages.get(pageIndex);
         ST_Box pageBox = pageInfo.getSize();
-        double pageWidthPixel = ppm * pageBox.getWidth();
-        double pageHeightPixel = ppm * pageBox.getHeight();
+        
+        //按照标准 ImageIO.write之后还需要对图片 exif dpi设置生成的dpi值 这样第三方通过像素和DPI换算出纸质尺寸
+        int pageWidthPixel = (int) Math.round(ppm * pageBox.getWidth());
+        int pageHeightPixel = (int) Math.round(ppm * pageBox.getHeight());
 
-        BufferedImage image = createImage((int) pageWidthPixel, (int) pageHeightPixel);
+        BufferedImage image = createImage(pageWidthPixel,pageHeightPixel);
         Graphics2D graphics = (Graphics2D) image.getGraphics();
 
         writePage(graphics, pageInfo, null);

--- a/ofdrw-converter/src/main/java/org/ofdrw/converter/ImageMaker.java
+++ b/ofdrw-converter/src/main/java/org/ofdrw/converter/ImageMaker.java
@@ -37,7 +37,7 @@ public class ImageMaker extends AWTMaker {
      * OFD内部使用毫米作为基本单位
      *
      * @param reader OFD解析器
-     * @param ppm    每毫米像素数量(Pixels per millimeter) 调用CommonUtil.dpiToPixel(200) 给定DPI下的像素数量
+     * @param ppm    每毫米像素数量(Pixels per millimeter) 调用CommonUtil.dpiToPpm(200) 给定DPI下的像素数量
      */
 
     public ImageMaker(OFDReader reader,double ppm) {

--- a/ofdrw-converter/src/main/java/org/ofdrw/converter/SVGMaker.java
+++ b/ofdrw-converter/src/main/java/org/ofdrw/converter/SVGMaker.java
@@ -63,8 +63,9 @@ public class SVGMaker extends AWTMaker {
         }
         PageInfo pageInfo = pages.get(pageIndex);
         ST_Box pageBox = pageInfo.getSize();
-        int pageWidthPixel = Double.valueOf(ppm * pageBox.getWidth()).intValue();
-        int pageHeightPixel = Double.valueOf(ppm * pageBox.getHeight()).intValue();
+        
+        int pageWidthPixel = (int) Math.round(ppm * pageBox.getWidth());
+        int pageHeightPixel = (int) Math.round(ppm * pageBox.getHeight());
 
         DOMImplementation domImpl = GenericDOMImplementation.getDOMImplementation();
 

--- a/ofdrw-converter/src/main/java/org/ofdrw/converter/SVGMaker.java
+++ b/ofdrw-converter/src/main/java/org/ofdrw/converter/SVGMaker.java
@@ -19,6 +19,7 @@ import java.io.Writer;
  * SVG转换类
  *
  * @author qaqtutu
+ * @version iandjava
  * @since 2021-05-06 23:00:01
  */
 public class SVGMaker extends AWTMaker {
@@ -32,8 +33,21 @@ public class SVGMaker extends AWTMaker {
      * @param reader OFD解析器
      * @param ppm    每毫米像素数量(Pixels per millimeter)
      */
-
+	@Deprecated
     public SVGMaker(OFDReader reader, int ppm) {
+        super(reader, ppm);
+    }
+    
+    /**
+     * 创建SVG转换对象实例
+     * <p>
+     * OFD内部使用毫米作为基本单位
+     *
+     * @param reader OFD解析器
+     * @param ppm    每毫米像素数量(Pixels per millimeter) 调用CommonUtil.dpiToPpm(200) 给定DPI下的像素数量
+     */
+
+    public SVGMaker(OFDReader reader,double ppm) {
         super(reader, ppm);
     }
 

--- a/ofdrw-converter/src/main/java/org/ofdrw/converter/utils/CommonUtil.java
+++ b/ofdrw-converter/src/main/java/org/ofdrw/converter/utils/CommonUtil.java
@@ -28,6 +28,7 @@ import java.util.UUID;
 
 /**
  * @author dltech21
+ * @author  iandjava
  * @since 2020/8/11
  */
 public class CommonUtil {
@@ -36,9 +37,19 @@ public class CommonUtil {
         return (double) (mm * dpi / 25.4f);
     }
 
+    
     public static double pixelToMillimeters(double px, double dpi) {
         //像素转毫米：px * 25.4 / dpi
         return (double) ((px * 25.4f) / dpi);
+    }
+    
+    /**
+     * 获取指定DPI下的每毫米像素数量
+     * @param dpi 每英寸的像素 如200、300
+     * @return
+     */
+    public static double dpiToPixel(int dpi) {
+    	return ((0.01/0.254)*dpi);
     }
 
     public static float[] doubleArrayToFloatArray(Double[] doubleArray) {

--- a/ofdrw-converter/src/main/java/org/ofdrw/converter/utils/CommonUtil.java
+++ b/ofdrw-converter/src/main/java/org/ofdrw/converter/utils/CommonUtil.java
@@ -48,7 +48,7 @@ public class CommonUtil {
      * @param dpi 每英寸的像素 如200、300
      * @return
      */
-    public static double dpiToPixel(int dpi) {
+    public static double dpiToPpm(int dpi) {
     	return ((0.01/0.254)*dpi);
     }
 


### PR DESCRIPTION
ImageMaker、AWTMaker构造函数扩展 double类型ppm参数 原先int类型过期处理。
CommonUtil新增dpiToPixel函数 获取指定DPI下的每毫米像素数量