### PR TITLE
修复XXE & zip slip 漏洞

### DIFF
--- a/ofdrw-pkg/src/main/java/org/ofdrw/pkg/tool/ElemCup.java
+++ b/ofdrw-pkg/src/main/java/org/ofdrw/pkg/tool/ElemCup.java
@@ -35,7 +35,7 @@ public class ElemCup {
      * @throws DocumentException 文件解析异常
      */
     public static Element inject(Path file) throws DocumentException {
-        SAXReader reader = new SAXReader();
+        SAXReader reader = SAXReaderFactory.create();
         try (InputStream in = Files.newInputStream(file)) {
             Document document = reader.read(in);
             return document.getRootElement();

--- a/ofdrw-pkg/src/main/java/org/ofdrw/pkg/tool/SAXReaderFactory.java
+++ b/ofdrw-pkg/src/main/java/org/ofdrw/pkg/tool/SAXReaderFactory.java
@@ -1,0 +1,49 @@
+package org.ofdrw.pkg.tool;
+
+import java.util.function.Supplier;
+import org.dom4j.io.SAXReader;
+
+/**
+ * @author gongxiangyang
+ * @date 2022/5/7 11:29
+ * SAXReader 工厂
+ */
+public class SAXReaderFactory
+{
+
+    /**
+     * 用户自定义生成器
+     */
+    private static Supplier<SAXReader> CustomizeProducer = null;
+
+
+    /**
+     * 设置用户自定义的 SAXReader 生成器
+     * @param SAXReaderProducer
+     */
+    public static synchronized void SetCustomizedProducer(Supplier<SAXReader> SAXReaderProducer)
+    {
+        if (null == CustomizeProducer)
+        {
+            SAXReaderFactory.CustomizeProducer = SAXReaderProducer;
+        }
+    }
+
+
+    /**
+     * 创建 SAXReader 实例
+     * @return SAXReader 对象
+     * 若用户未配置，则调用 SAXReader.createDefault()创建，否则调用用户定义的生成器逻辑
+     */
+    public static SAXReader create()
+    {
+        if (null == CustomizeProducer)
+        {
+            return SAXReader.createDefault();
+        }
+        else
+        {
+            return CustomizeProducer.get();
+        }
+    }
+}

--- a/ofdrw-reader/src/main/java/org/ofdrw/reader/ZipUtil.java
+++ b/ofdrw-reader/src/main/java/org/ofdrw/reader/ZipUtil.java
@@ -138,7 +138,12 @@ public class ZipUtil {
             Enumeration<? extends ZipEntry> entries = zipFile.entries();
             while (entries.hasMoreElements()) {
                 entry = entries.nextElement();
-                File f = new File(pathFile, entry.getName());
+
+                File f = new File(pathFile, entry.getName()).getCanonicalFile();
+
+                //校验路径合法性
+                pathValid(pathFile.getAbsolutePath(), f.getAbsolutePath());
+
                 if (entry.isDirectory()) {
                     if (!f.isDirectory() && !f.mkdirs()) {
                         throw new IOException("failed to create directory " + f);


### PR DESCRIPTION
1.修复XXE漏洞。默认采用dom4j提供createDefault方法创建SAXReader对象；
2.修复zip slip漏洞