### PR TITLE
fix: ST_Array getInstance error when DashPattern is string null

### DIFF
--- a/ofdrw-core/src/main/java/org/ofdrw/core/basicType/ST_Array.java
+++ b/ofdrw-core/src/main/java/org/ofdrw/core/basicType/ST_Array.java
@@ -75,11 +75,11 @@ public class ST_Array extends STBase implements Cloneable {
     /**
      * 获取 ST_Array 实例如果参数非法则返还null
      *
-     * @param arrStr 数字字符串
+     * @param arrStr 数字字符串或者字符串null
      * @return 实例 或 null
      */
     public static ST_Array getInstance(String arrStr) {
-        if (arrStr == null || arrStr.trim().length() == 0) {
+        if (arrStr == null || "null".equals(arrStr) || arrStr.trim().length() == 0) {
             return null;
         }
         return new ST_Array(arrStr.trim().split("\\s+"));


### PR DESCRIPTION
issue https://github.com/ofdrw/ofdrw/issues/215

![image](https://github.com/ofdrw/ofdrw/assets/64742575/dab6e4e9-40ac-4c55-af82-ef58b19a944f)

when DashPattern is string null, ST_Array getInstance should return null, but now return ArrayList with element string null