### PR TITLE
fix: #223 FontLoader#getReplaceSimilarFontPath cause NPE

### DIFF
--- a/ofdrw-converter/src/main/java/org/ofdrw/converter/FontLoader.java
+++ b/ofdrw-converter/src/main/java/org/ofdrw/converter/FontLoader.java
@@ -398,6 +398,8 @@ public final class FontLoader {
         if (name != null && fontNamePathMapping.containsKey(name)) {
             return fontNamePathMapping.get(name);
         }
+
+        if (familyName == null) return null;
         name = fontNameAliasMapping.get(familyName);
         if (name != null && fontNamePathMapping.containsKey(name)) {
             return fontNamePathMapping.get(name);

--- a/ofdrw-converter/src/test/java/org/ofdrw/converter/FontLoaderTest.java
+++ b/ofdrw-converter/src/test/java/org/ofdrw/converter/FontLoaderTest.java
@@ -13,4 +13,12 @@ class FontLoaderTest {
         String p = instance.getSystemFontPath("宋体", null);
         System.out.println(p);
     }
+
+    @Test
+    void testNullFamilyName() {
+        FontLoader.DEBUG = true;
+        FontLoader instance = FontLoader.getInstance();
+        String p = instance.getSystemFontPath(null, "ThisFontNeverExistInYourSystem!!!");
+        assertNull(p);
+    }
 }


### PR DESCRIPTION
fix: #223 FontLoader#getReplaceSimilarFontPath will cause NPE when familyName is null and the font does not exist