### PR TITLE
修复ofd转图片线条丢失问题

### DIFF
--- a/ofdrw-converter/src/main/java/org/ofdrw/converter/OFDImageMaker.java
+++ b/ofdrw-converter/src/main/java/org/ofdrw/converter/OFDImageMaker.java
@@ -1,0 +1,45 @@
+package org.ofdrw.converter;
+
+import org.ofdrw.core.pageDescription.color.color.CT_Color;
+import org.ofdrw.reader.OFDReader;
+
+import java.awt.Color;
+
+/**
+ * 图片转换类-ofd转图片
+ * 如果图片边线/边框/线条丢失，可以尝试使用这个类转图片
+ * defaultStrokeColor-默认为红色边线
+ *
+ * @author yangzhenyi
+ * @since 2024-11-22 11:08:00
+ */
+public class OFDImageMaker extends ImageMaker {
+
+    private Color defaultStrokeColor = new Color(128, 0, 0);
+
+    public OFDImageMaker(OFDReader reader, int ppm) {
+        super(reader, ppm);
+    }
+
+    public OFDImageMaker(OFDReader reader, double ppm) {
+        super(reader, ppm);
+    }
+
+    public OFDImageMaker(OFDReader reader, int ppm, Color color) {
+        super(reader, ppm);
+        this.defaultStrokeColor = color;
+    }
+
+    public OFDImageMaker(OFDReader reader, double ppm, Color color) {
+        super(reader, ppm);
+        this.defaultStrokeColor = color;
+    }
+
+    @Override
+    public Color getColor(CT_Color ctColor) {
+        if (ctColor != null && ctColor.getValue() == null) {
+            return defaultStrokeColor;
+        }
+        return super.getColor(ctColor);
+    }
+}


### PR DESCRIPTION
当ofd有一张发票时能正常转成图片，但是当ofd包含两张发票时，第二张发票转成的图片没有边线和边框，如下图：
<img width="1064" alt="issue" src="https://github.com/user-attachments/assets/686b3fa0-472b-434d-86d7-198e0f38b16f">
cha'kan
查看第二张发票的xml数据和ofdrw有关path边线绘制的逻辑，应该是xml中边线的strokeColor属性值为空导致的，xml数据如下:
![image](https://github.com/user-attachments/assets/997d916a-91da-49e8-8218-0f70af92e50f)
由于ImageMaker类中并没有对strokeColor的value判空，因此继承了该类重写了getColor方法，如果使用该类绘制图片(ImageMaker imageMaker = new OFDImageMaker(ofdReader, ppm))，当strokeColor的value值为空时也能根据默认/自定义的颜色成功绘制图片边线而不是空白

