### PR TITLE
修复使用Itext转PDF字体颜色缺失的bug

### DIFF
--- a/ofdrw-converter/src/main/java/org/ofdrw/converter/ItextMaker.java
+++ b/ofdrw-converter/src/main/java/org/ofdrw/converter/ItextMaker.java
@@ -751,6 +751,12 @@ public class ItextMaker {
     private void writeText(ResourceManage resMgt, PdfCanvas pdfCanvas, ST_Box box, ST_Box sealBox, ST_Box annotBox, TextObject textObject, Color fillColor, int alpha, Integer compositeObjectAlpha, ST_Box compositeObjectBoundary, ST_Array compositeObjectCTM) throws IOException {
         double scale = scaling(sealBox, textObject);
     	float fontSize = Double.valueOf(textObject.getSize() * scale).floatValue();
+        CT_DrawParam ctDrawParam = resMgt.superDrawParam(textObject);
+        // 使用绘制参数补充缺省的颜色
+        if (ctDrawParam != null && textObject.getFillColor() == null
+                && ctDrawParam.getFillColor() != null) {
+            fillColor = ColorConvert.pdfRGB(resMgt, ctDrawParam.getFillColor());
+        }
         pdfCanvas.setFillColor(fillColor);
         if (textObject.getFillColor() != null) {
             Element e = textObject.getFillColor().getOFDElement("AxialShd");


### PR DESCRIPTION
使用Cell元素的文本，指定字体颜色后通过Itext转换为PDF发现字体颜色丢失，参照PDFbox转换的逻辑修复了这个Bug
复现代码
```Java
    private Cell createCell(String value, double width, double height) {
        Cell cell = new Cell(width, height);
        cell.setValue(value)
                .setFontName(FontName.KaiTi.name())
                .setFontSize(9d * ptTOMM)
                .setColor(MAIN_COLOR)
                .setTextAlign(TextAlign.center)
                .setVerticalAlign(VerticalAlign.center);
        return cell;
    }
```
![image](https://github.com/user-attachments/assets/2ff22a58-820d-431c-b1b5-29c81b769bf6)

