### PR TITLE
修复使用PDFbox转PDF时框线宽度不正确的bug

### DIFF
--- a/ofdrw-converter/src/main/java/org/ofdrw/converter/PdfboxMaker.java
+++ b/ofdrw-converter/src/main/java/org/ofdrw/converter/PdfboxMaker.java
@@ -512,7 +512,7 @@ public class PdfboxMaker {
             contentStream.setMiterLimit(pathObject.getMiterLimit().floatValue());
             path(contentStream, box, sealBox, annotBox, pathObject, compositeObjectBoundary, compositeObjectCTM);
             if (pathObject.getLineWidth() != null && pathObject.getLineWidth() > 0) {
-                contentStream.setLineWidth( pathObject.getLineWidth().floatValue());
+                contentStream.setLineWidth((float) converterDpi(pathObject.getLineWidth()));
             }
             PDShading shading = parseShading(strokeColor, box, pathObject);
             if (shading != null) {


### PR DESCRIPTION
修改前:
![image](https://github.com/user-attachments/assets/4fee9f97-d745-4bbc-9715-b5e4c5f23e8c)
修改后:
![image](https://github.com/user-attachments/assets/12787473-cef1-4b36-88c0-1a323c07c709)

根本原因是转换时没有将毫米单位转为像素