### PR TITLE
fix: 修复ofd转pdf时附件名称错误

### DIFF
--- a/ofdrw-converter/src/main/java/org/ofdrw/converter/PdfboxMaker.java
+++ b/ofdrw-converter/src/main/java/org/ofdrw/converter/PdfboxMaker.java
@@ -921,8 +921,8 @@ public class PdfboxMaker {
             PDComplexFileSpecification fs = new PDComplexFileSpecification();
             Path attFile = ofdReader.getAttachmentFile(attachment);
             // 文件名传
-            fs.setFile(attFile.getFileName().toString());
-
+            fs.setFile(attachment.getAttachmentName());
+            fs.setFileUnicode(attachment.getAttachmentName());
             // 文件流，该流将由PDEmbeddedFile内部关闭
             PDEmbeddedFile ef = new PDEmbeddedFile(pdf, Files.newInputStream(attFile));
             // 文件类型

--- a/ofdrw-converter/src/test/java/org/ofdrw/converter/ofdconverter/PDFConverterTest.java
+++ b/ofdrw-converter/src/test/java/org/ofdrw/converter/ofdconverter/PDFConverterTest.java
@@ -139,7 +139,8 @@ class PDFConverterTest {
         Path[] arr = new Path[]{
                 Paths.get("src/test/resources/img.jpg"),
                 Paths.get("src/test/resources/log4j2.xml"),
-                Paths.get("src/test/resources/helloworld.ofd")
+                Paths.get("src/test/resources/helloworld.ofd"),
+                Paths.get("src/test/resources/intro-数科.ofd")
         };
         try (PDDocument pdfDoc =  PDDocument.load(src.toFile())) {
             PDEmbeddedFilesNameTreeNode efTree = new PDEmbeddedFilesNameTreeNode();


### PR DESCRIPTION
在测试用例中加入文件名带中文的文件后，发现wps打开生成的pdf中附件文件名为"?"
