### PR TITLE
fix：修复当Annot为超链接类型时，不绘制外边框

### DIFF
--- a/ofdrw-converter/src/main/java/org/ofdrw/converter/ItextMaker.java
+++ b/ofdrw-converter/src/main/java/org/ofdrw/converter/ItextMaker.java
@@ -254,9 +254,9 @@ public class ItextMaker {
             for (Annot annot : annotList) {
 
 	            // 超链接类型，注释不绘制
-	            // if (annot.getType() == AnnotType.Link) {
-		        //     continue;
-	            // }
+	            if (annot.getType() == AnnotType.Link) {
+		            continue;
+	            }
 
                 Appearance appearance = annot.getAppearance();
                 if (appearance == null) {

--- a/ofdrw-converter/src/main/java/org/ofdrw/converter/ItextMaker.java
+++ b/ofdrw-converter/src/main/java/org/ofdrw/converter/ItextMaker.java
@@ -30,6 +30,7 @@ import org.ofdrw.converter.utils.CommonUtil;
 import org.ofdrw.converter.utils.PointUtil;
 import org.ofdrw.converter.utils.StringUtils;
 import org.ofdrw.core.annotation.pageannot.Annot;
+import org.ofdrw.core.annotation.pageannot.AnnotType;
 import org.ofdrw.core.annotation.pageannot.Appearance;
 import org.ofdrw.core.attachment.CT_Attachment;
 import org.ofdrw.core.basicStructure.pageObj.layer.CT_Layer;
@@ -251,6 +252,12 @@ public class ItextMaker {
                 continue;
             }
             for (Annot annot : annotList) {
+
+	            // 超链接类型，注释不绘制
+	            // if (annot.getType() == AnnotType.Link) {
+		        //     continue;
+	            // }
+
                 Appearance appearance = annot.getAppearance();
                 if (appearance == null) {
                     continue;


### PR DESCRIPTION
当文字为可点击的超链接类型时，OFD转PDF会对文字的外边框进行绘制，
此pr选择跳过外边框绘制，保证正确转换PDF

可使用以下文档进行验证
[超链接绘制外边框-下载后修改后缀名为ofd.txt](https://github.com/user-attachments/files/20075558/-.ofd.txt)

![image](https://github.com/user-attachments/assets/de3714b5-b51f-4e3b-b204-d198d29a3baf)

