### PR TITLE
fix：当字符索引标签缺失且cmap为空时，需加载操作系统字体 + 修复：文字透明度没有随着alpha属性变化

### DIFF
--- a/ofdrw-converter/src/main/java/com/itextpdf/io/font/ItextTrueTypeFont.java
+++ b/ofdrw-converter/src/main/java/com/itextpdf/io/font/ItextTrueTypeFont.java
@@ -9,6 +9,7 @@ import com.itextpdf.io.util.IntHashtable;
 
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -28,6 +29,9 @@ import java.util.SortedSet;
 public class ItextTrueTypeFont extends TrueTypeFont {
 
     private static final long serialVersionUID = -2232044646577669268L;
+
+    /** 默认为非空，如果解析到cmap表为空，则设置为true */
+    public boolean isEmptyCmap = false;
 
     private OpenTypeParser fontParser;
 
@@ -259,6 +263,12 @@ public class ItextTrueTypeFont extends TrueTypeFont {
         fontIdentification.setPanose(pdfPanose);
 
         Map<Integer, int[]> cmap = getActiveCmap();
+        // 如果没有可用的cmap，则将isEmptyCmap设置为true
+        if (Objects.isNull(cmap) || cmap.isEmpty()) {
+            isEmptyCmap = true;
+            cmap = Collections.emptyMap();
+        }
+
         int[] glyphWidths = fontParser.getGlyphWidthsByIndex();
         int numOfGlyphs = fontMetrics.getNumberOfGlyphs();
         unicodeToGlyph = new LinkedHashMap<>(cmap.size());

--- a/ofdrw-converter/src/main/java/org/ofdrw/converter/ItextMaker.java
+++ b/ofdrw-converter/src/main/java/org/ofdrw/converter/ItextMaker.java
@@ -856,6 +856,12 @@ public class ItextMaker {
                 ry = textCodePoint.y;
             }
             pdfCanvas.saveState();
+
+	        // 文字透明度
+	        if (textObject.getFill()) {
+		        pdfCanvas.setExtGState(new PdfExtGState().setFillOpacity(textObject.getAlpha() / 255f));
+	        }
+
             pdfCanvas.beginText();
             if (textObject.getMiterLimit() > 0)
                 pdfCanvas.setMiterLimit(textObject.getMiterLimit().floatValue());

--- a/ofdrw-converter/src/main/java/org/ofdrw/converter/ItextMaker.java
+++ b/ofdrw-converter/src/main/java/org/ofdrw/converter/ItextMaker.java
@@ -844,7 +844,7 @@ public class ItextMaker {
 
         // 加载字体
         CT_Font ctFont = resMgt.getFont(textObject.getFont().toString());
-        FontWrapper<PdfFont> pdfFontWrapper = getFont(resMgt.getOfdReader().getResourceLocator(), ctFont);
+        FontWrapper<PdfFont> pdfFontWrapper = getFont(resMgt.getOfdReader().getResourceLocator(), ctFont, textObject.getCGTransforms().isEmpty());
         PdfFont font = pdfFontWrapper.getFont();
 
         List<TextCodePoint> textCodePointList = PointUtil.calPdfTextCoordinate(box.getWidth(), box.getHeight(), textObject.getBoundary(), fontSize, textObject.getTextCodes(), textObject.getCGTransforms(), compositeObjectBoundary, compositeObjectCTM, textObject.getCTM() != null, textObject.getCTM(), true, scale);
@@ -951,14 +951,15 @@ public class ItextMaker {
      *
      * @param rl     资源加载器
      * @param ctFont 字体对象
+     * @param isNoGlyphs 是否不存在字符索引
      * @return 字体
      */
-    private FontWrapper<PdfFont> getFont(ResourceLocator rl, CT_Font ctFont) {
+    private FontWrapper<PdfFont> getFont(ResourceLocator rl, CT_Font ctFont, boolean isNoGlyphs) {
         String key = String.format("%s_%s_%s", ctFont.getFamilyName(), ctFont.attributeValue("FontName"), ctFont.getFontFile());
         if (fontCache.containsKey(key)) {
             return fontCache.get(key);
         }
-        FontWrapper<PdfFont> font = FontLoader.getInstance().loadPDFFontSimilar(rl, ctFont);
+        FontWrapper<PdfFont> font = FontLoader.getInstance().loadPDFFontSimilar(rl, ctFont, isNoGlyphs);
         fontCache.put(key, font);
         return font;
     }


### PR DESCRIPTION
**1. 文字透明度没有随着alpha属性变化，导致颜色过深**
可使用以下文件进行验证：
[发票水印问题-下载后修改后缀为ofd.txt](https://github.com/user-attachments/files/20183062/-.ofd.txt)
![image](https://github.com/user-attachments/assets/51f8d4f3-3b20-4d28-82c9-240aba59b46b)

**2. 当字符索引标签缺失且cmap为空时，需加载操作系统字体，否则会变成未知字符**
可使用以下文件进行验证：
[缺失字符索引-下载后修改后缀为ofd.txt](https://github.com/user-attachments/files/20183079/-.ofd.txt)
![image](https://github.com/user-attachments/assets/31841751-83ef-4bee-bfd6-60099f465e94)
