### PR TITLE
fix：修复加载内嵌字体失败，最大程度加载内嵌字体

### DIFF
--- a/ofdrw-converter/src/main/java/com/itextpdf/io/font/ItextTrueTypeFont.java
+++ b/ofdrw-converter/src/main/java/com/itextpdf/io/font/ItextTrueTypeFont.java
@@ -248,13 +248,15 @@ public class ItextTrueTypeFont extends TrueTypeFont {
 
         // font identification group
         String[][] ttfVersion = fontNames.getNames(5);
-        if (ttfVersion != null) {
+        /** 代码修改 start */
+        if (ttfVersion != null && ttfVersion.length > 0 && ttfVersion[0].length > 3) {
             fontIdentification.setTtfVersion(ttfVersion[0][3]);
         }
         String[][] ttfUniqueId = fontNames.getNames(3);
-        if (ttfUniqueId != null) {
+        if (ttfUniqueId != null && ttfUniqueId.length > 0 && ttfUniqueId[0].length > 3) {
             fontIdentification.setTtfVersion(ttfUniqueId[0][3]);
         }
+        /** 代码修改 end */
 
         byte[] pdfPanose = new byte[12];
         pdfPanose[1] = (byte) (os_2.sFamilyClass);


### PR DESCRIPTION
ofd内嵌的字体文件，很多都是不规范的、不一定完整的字体文件
但是如果要完美实现预览，肯定还是能成功加载内嵌字体是最好的；
加载系统安装字体文件方案的劣势，一个是需要独立安装，一个是还得提前知道内嵌字体是用的啥字体，去哪下载

所以此PR优化了字体加载逻辑，保证能最大程度加载出内嵌字体且保证预览效果不出现偏差
可使用以下文档进行验证：
[字体加载失败问题-下载后修改后缀为ofd.txt](https://github.com/user-attachments/files/20201127/-.ofd.txt)
![image](https://github.com/user-attachments/assets/349c1882-d211-4f20-bcf8-a6aafd107dd0)

修复后效果：
![image](https://github.com/user-attachments/assets/aa931d31-759b-422e-ae29-a2c8ceca0d57)
