### PR TITLE
fix：剪裁文字实际绘制区域

### DIFF
--- a/ofdrw-converter/src/main/java/org/ofdrw/converter/ItextMaker.java
+++ b/ofdrw-converter/src/main/java/org/ofdrw/converter/ItextMaker.java
@@ -855,6 +855,15 @@ public class ItextMaker {
         PdfFont font = pdfFontWrapper.getFont();
 
         List<TextCodePoint> textCodePointList = PointUtil.calPdfTextCoordinate(box.getWidth(), box.getHeight(), textObject.getBoundary(), fontSize, textObject.getTextCodes(), textObject.getCGTransforms(), compositeObjectBoundary, compositeObjectCTM, textObject.getCTM() != null, textObject.getCTM(), true, scale);
+
+	    // 创建矩形对象, 指定文字绘制区域
+	    ST_Box boundary = textObject.getBoundary();
+	    Rectangle rectangle = new Rectangle(
+			    (float) converterDpi(boundary.getTopLeftX()),
+			    (float) converterDpi(box.getHeight() - boundary.getTopLeftY() - boundary.getHeight()),
+			    (float) converterDpi(boundary.getWidth()),
+			    (float) converterDpi(boundary.getHeight()));
+
         double rx = 0, ry = 0;
         for (int i = 0; i < textCodePointList.size(); i++) {
             TextCodePoint textCodePoint = textCodePointList.get(i);
@@ -868,6 +877,11 @@ public class ItextMaker {
 	        if (textObject.getFill()) {
 		        pdfCanvas.setExtGState(new PdfExtGState().setFillOpacity(textObject.getAlpha() / 255f));
 	        }
+
+	        // 剪裁文字实际绘制区域
+	        pdfCanvas.rectangle(rectangle); // 绘制剪裁区域
+	        pdfCanvas.clip();    // 通过将当前剪切路径与当前路径相交来修改当前剪切路径
+	        pdfCanvas.endPath(); // 让剪裁操作生效
 
             pdfCanvas.beginText();
             if (textObject.getMiterLimit() > 0)


### PR DESCRIPTION
每段文字都有外接矩形，限制其内部文字的绘制区域，如果超出外接矩形区域应该进行裁剪

上一个PR：https://github.com/ofdrw/ofdrw/pull/372
虽然增强了字体文件加载，但是还有部分字符超出了外接矩形区域，本次进行修复，仍可使用上次PR文件进行验证

也可使用下面的文件进行验证：
[文字裁剪-下载后修改后缀为ofd.txt](https://github.com/user-attachments/files/20218696/-.ofd.txt)

修复后，预期效果如下：
因为我调小了前两句的外接矩形的宽高，前两句超出矩形区域应该不显示
![image](https://github.com/user-attachments/assets/5b923d7e-cb0d-4f51-8a2d-200fcbd9967b)
