### PR TITLE
fix：修复竖向排版文字坐标计算错误问题

### DIFF
--- a/ofdrw-converter/src/main/java/org/ofdrw/converter/utils/PointUtil.java
+++ b/ofdrw-converter/src/main/java/org/ofdrw/converter/utils/PointUtil.java
@@ -412,12 +412,15 @@ public class PointUtil {
                             double e = ctms[4].doubleValue();
                             double f = ctms[5].doubleValue();
                             double angel = Math.atan2(-b, d);
+
+                            double[] newPoint = ctmCalPoint(dx, 0, ctm.toDouble());
+                            // 无旋转时直接应用CTM
                             if (angel == 0) {
-                                double[] newPoint = ctmCalPoint(dx, 0, ctm.toDouble());
                                 dx = newPoint[0];
                             } else {
+                                // 如果竖排文字，水平偏移转化为变换后坐标的垂直分量
                                 if (a == 0 && d == 0) {
-                                    dx = dx * fontSize;
+                                    dx = Math.abs(newPoint[1]); // 取绝对值防止负数
                                 }
                             }
                         } else {


### PR DESCRIPTION
之前的代码对竖向文字的间距计算有误，文字的间距与CTM矩阵是紧密相关的，本次进行修复

可使用下面的文件进行验证：
[竖向文字排版-下载后修改后缀为ofd.txt](https://github.com/user-attachments/files/20359165/-.ofd.txt)

修复前效果：竖向文字间距过大
![image](https://github.com/user-attachments/assets/cb383997-99e0-45ef-8077-4da97d1f42e5)
