### PR TITLE
fix：支持斜体文字

### DIFF
--- a/ofdrw-converter/src/main/java/org/ofdrw/converter/ItextMaker.java
+++ b/ofdrw-converter/src/main/java/org/ofdrw/converter/ItextMaker.java
@@ -934,6 +934,21 @@ public class ItextMaker {
 	            }
             }
 
+	        // 设置文字斜体
+	        if (textObject.getItalic()) {
+		        // 计算剪切因子（角度=10°）
+		        double shearFactor = Math.tan(Math.toRadians(10));
+
+		        // 定义补偿量：补偿量 = 剪切因子 * 字体高度
+		        double compensation = shearFactor * textCodePoint.getY();
+
+		        // 构建组合变换矩阵（反向平移且剪切）
+		        AffineTransform transform = new AffineTransform();
+		        transform.translate(-compensation, 0); // 反向平移补偿偏移
+		        transform.shear(shearFactor, 0);     // 应用剪切
+		        pdfCanvas.concatMatrix(transform);
+	        }
+
             //设置字符方向
             if (textObject.getCharDirection() == Angle_90) {
                 pdfCanvas.setTextMatrix(0, -1, 1, 0, (float) textCodePoint.getX(), (float) textCodePoint.getY());


### PR DESCRIPTION
之前未处理字体是斜体的情况，此PR进行补充

可使用下面的文件进行验证（由于测试文件使用了竖向排版，建议先合并上一个PR：https://github.com/ofdrw/ofdrw/pull/374）：
[竖向排版+裁剪+斜体-下载后修改后缀为ofd.txt](https://github.com/user-attachments/files/20359342/%2B.%2B.-.ofd.txt)

修复后效果如下：
![image](https://github.com/user-attachments/assets/39ba5ea5-7585-4277-9c73-d8b003638d41)
