### PR TITLE
fix：PDF文档转OFD格式，图元剪裁时，增加对设置CTM矩阵的判断

### DIFF
--- a/ofdrw-graphics2d/src/main/java/org/ofdrw/graphics2d/OFDGraphics2DDrawParam.java
+++ b/ofdrw-graphics2d/src/main/java/org/ofdrw/graphics2d/OFDGraphics2DDrawParam.java
@@ -23,6 +23,11 @@ import java.awt.geom.AffineTransform;
 public class OFDGraphics2DDrawParam {
 
     /**
+     * 剪裁区域是否已手动变换
+     */
+    public boolean isTransformClip = false;
+
+    /**
      * 文档上下文
      */
     private final OFDGraphicsDocument docCtx;

--- a/ofdrw-graphics2d/src/main/java/org/ofdrw/graphics2d/OFDPageGraphics2D.java
+++ b/ofdrw-graphics2d/src/main/java/org/ofdrw/graphics2d/OFDPageGraphics2D.java
@@ -880,6 +880,9 @@ public class OFDPageGraphics2D extends Graphics2D {
         // 如果不是单位矩阵则对路径进行变换
         if (!this.drawParam.ctm.isIdentity()) {
             s = this.drawParam.ctm.createTransformedShape(s);
+            this.drawParam.isTransformClip = true;
+        } else {
+            this.drawParam.isTransformClip = false;
         }
         this.drawParam.clip = new Area(s);
     }
@@ -1327,12 +1330,13 @@ public class OFDPageGraphics2D extends Graphics2D {
             clipObj.setFill(true);
             clipObj.setBoundary(this.size);
             try {
-                // 由于图元内的裁剪区域受到图元的变换矩阵影响，
-                // 而裁剪区域是位于未受到变换的原始画布上的区域，
-                // 因此在图元内部的裁剪区为需要叠加一个图元内变换的逆变换，
+                // 如果剪裁区域已经转换到OFD的页面空间上， 则不需要进行矩阵转换；
+                // 如果剪裁区域仍处于原始画布，则需要在图元内部的裁剪区叠加一个图元内变换的逆变换，
                 // 才可以实现向外部空间的映射。
-                AffineTransform inverse = objCTM.createInverse();
-                clipObj.setCTM(trans(inverse));
+                if (!this.drawParam.isTransformClip) {
+                    AffineTransform inverse = objCTM.createInverse();
+                    clipObj.setCTM(trans(inverse));
+                }
                 area.setClipObj(clipObj);
                 clips.addClip(new CT_Clip().addArea(area));
                 return clips;


### PR DESCRIPTION
如果剪裁区域已经转换到OFD的页面空间上， 则不需要进行矩阵转换；
否则在剪裁时会被判定图元不在剪裁区域内，导致图元消失


可使用下面的文件进行验证：
[横线剪裁问题.pdf](https://github.com/user-attachments/files/20532430/default.pdf)

当前的问题是，
PDF文档第二页应该是有三条横线的，
由于转OFD时错误的给第一条横线设置了CTM，导致横线被剪裁掉了
![image](https://github.com/user-attachments/assets/6a8982e3-8ac3-488c-bb03-2402e2c757df)
