### PR TITLE
fix: 修复 AbbreviatedData.parse() 路径解析 Bug 导致 OFD 转 SVG 出现大面色块

### DIFF
--- a/ofdrw-core/src/main/java/org/ofdrw/core/graph/pathObj/AbbreviatedData.java
+++ b/ofdrw-core/src/main/java/org/ofdrw/core/graph/pathObj/AbbreviatedData.java
@@ -60,6 +60,10 @@ public class AbbreviatedData extends OFDElement implements Cloneable, Iterator<O
         String opt = null;
         List<String> values = new LinkedList<>();
         for (String s : arr) {
+            if (s.isEmpty()) {
+                // 跳过split产生的空字符串（如前导空格导致的""）
+                continue;
+            }
             switch (s) {
                 case "S":
                 case "M":
@@ -71,9 +75,8 @@ public class AbbreviatedData extends OFDElement implements Cloneable, Iterator<O
                 case "CM":
                     if (opt != null) {
                         res.add(new OptVal(opt, values));
-                        values.clear();
-                        opt = null;
                     }
+                    values = new LinkedList<>();
                     opt = s;
                     break;
                 default:

--- a/ofdrw-core/src/main/java/org/ofdrw/core/graph/pathObj/OptVal.java
+++ b/ofdrw-core/src/main/java/org/ofdrw/core/graph/pathObj/OptVal.java
@@ -88,6 +88,9 @@ public class OptVal implements Cloneable {
         if (arr.length < num) {
             return Arrays.copyOf(arr, num);
         }
+        if (arr.length > num) {
+            return Arrays.copyOf(arr, num);
+        }
         return arr;
     }
 


### PR DESCRIPTION
问题：OFD 路径数据以空格开头时（如 " M 30.0567 31.1573 L ..."），
split("\\s+") 产生空字符串 "" 作为首个元素，导致：

1. 空字符串被 Double.parseDouble 后赋值为 0.0，污染 values 列表
2. moveTo 的坐标从 [30.0567, 31.1573] 变成 [0.0, 30.0567]
3. 路径从页面左边缘 (x=0) 开始绘制，产生大面积色块

修复：
- AbbreviatedData.parse(): 跳过 split 产生的空字符串
- AbbreviatedData.parse(): values.clear() 改为 new LinkedList<>() 修复已加入 res 的引用被清空的 Bug
- OptVal.filling(): 数组超长时截断而非原样返回