### PR TITLE
add: 添加DOC_TYPE="OFD-A"支持.

### DIFF
--- a/ofdrw-core/src/main/java/org/ofdrw/core/basicStructure/ofd/OFDA.java
+++ b/ofdrw-core/src/main/java/org/ofdrw/core/basicStructure/ofd/OFDA.java
@@ -1,0 +1,76 @@
+package org.ofdrw.core.basicStructure.ofd;
+
+import org.dom4j.Element;
+
+import java.util.List;
+
+/**
+ * OFD 档案应用主入口扩展类
+ * <p>
+ * 专门用于满足《信息技术 OFD档案应用指南 GB/T 42133-2022》中关于 DOC_TYPE 为 "OFD-A" 的要求。
+ */
+public class OFDA extends OFD {
+
+    /**
+     * 文件格式子集类型，取值为“OFD-A”
+     */
+    public static final String DOC_TYPE_OFD_A = "OFD-A";
+
+    public OFDA(Element proxy) {
+        super(proxy);
+    }
+
+    public OFDA() {
+        super();
+        this.addAttribute("DocType", DOC_TYPE_OFD_A);
+    }
+
+    /**
+     * 文件对象入口列表创建文档对象
+     *
+     * @param docBodies 文件对象入口序列
+     */
+    public OFDA(List<DocBody> docBodies) {
+        this();
+        for (DocBody item : docBodies) {
+            if (item != null) {
+                this.add(item);
+            }
+        }
+    }
+
+    /**
+     * 文件对象入口创建文档对象
+     *
+     * @param docBody 文件对象入口
+     */
+    public OFDA(DocBody docBody) {
+        this();
+        this.add(docBody);
+    }
+
+    /**
+     * 【必选 属性】设置 文件版本号
+     *
+     * @param version 版本号
+     * @return this (OFDA 实例)
+     */
+    @Override
+    public OFDA setVersion(String version) {
+        super.setVersion(version);
+        return this;
+    }
+
+    /**
+     * 【必选】增加文件对象入口。
+     * 文件对象入口，可以存在多个，以便在一个文档中包含多个版式文档
+     *
+     * @param docBody 文件对象入口
+     * @return this (OFDA 实例)
+     */
+    @Override
+    public OFDA addDocBody(DocBody docBody) {
+        super.addDocBody(docBody);
+        return this;
+    }
+}

--- a/ofdrw-core/src/test/java/org/ofdrw/core/basicStructure/ofd/OFDATest.java
+++ b/ofdrw-core/src/test/java/org/ofdrw/core/basicStructure/ofd/OFDATest.java
@@ -1,0 +1,17 @@
+package org.ofdrw.core.basicStructure.ofd;
+
+import org.junit.jupiter.api.Test;
+import org.ofdrw.TestTool;
+
+public class OFDATest {
+    public static OFDA ofdCase(){
+        return new OFDA()
+                .addDocBody(DocBodyTest.docBodyCase())
+                .addDocBody(DocBodyTest.docBodyCase());
+    }
+
+    @Test
+    public void gen(){
+        TestTool.genXml("OFD", doc ->doc.add(ofdCase()));
+    }
+}

--- a/ofdrw-pkg/src/test/java/org/ofdrw/pkg/container/content/OFDContent.java
+++ b/ofdrw-pkg/src/test/java/org/ofdrw/pkg/container/content/OFDContent.java
@@ -3,6 +3,7 @@ package org.ofdrw.pkg.container.content;
 import org.junit.jupiter.api.Test;
 import org.ofdrw.core.basicStructure.ofd.DocBody;
 import org.ofdrw.core.basicStructure.ofd.OFD;
+import org.ofdrw.core.basicStructure.ofd.OFDA;
 import org.ofdrw.core.basicStructure.ofd.docInfo.CT_DocInfo;
 import org.ofdrw.core.basicType.ST_Loc;
 import org.ofdrw.pkg.container.TT;
@@ -25,9 +26,25 @@ public class OFDContent {
                 .addDocBody(docBody);
     }
 
+    public static OFDA ofda(){
+        CT_DocInfo docInfo = new CT_DocInfo()
+                .setDocID(UUID.randomUUID())
+                .setAuthor("权观宇")
+                .setCreationDate(LocalDate.now())
+                .setCreator("ofd r&w")
+                .setCreatorVersion("1.0.0-SNAPSHOT");
+        DocBody docBody = new DocBody()
+                .setDocInfo(docInfo)
+                .setDocRoot(new ST_Loc("Doc_0/Document.xml"));
+        return new OFDA()
+                .addDocBody(docBody);
+    }
+
     @Test
     public void printReview() throws Exception {
         OFD ofd = ofd();
         TT.dumpToTmpReview(ofd);
+        OFDA ofda = ofda();
+        TT.dumpToTmpReview(ofda);
     }
 }


### PR DESCRIPTION
现行标准有一个 “信息技术 OFD档案应用指南”， 标准号：GB/T 42133-2022。 增加了相关的支持。
允许设置 DocType 的属性值。