### PR TITLE
fix: 修复 PDFBox 导出文字矩阵与坐标转换

### DIFF
--- a/ofdrw-converter/src/main/java/org/ofdrw/converter/PdfboxMaker.java
+++ b/ofdrw-converter/src/main/java/org/ofdrw/converter/PdfboxMaker.java
@@ -872,7 +872,7 @@ public class PdfboxMaker {
 
     }
 
-    private Matrix textMatrix(TextObject textObject, TextCodePoint textCodePoint) {
+    static Matrix textMatrix(TextObject textObject, TextCodePoint textCodePoint) {
         double a = 1;
         double b = 0;
         double c = 0;

--- a/ofdrw-converter/src/main/java/org/ofdrw/converter/PdfboxMaker.java
+++ b/ofdrw-converter/src/main/java/org/ofdrw/converter/PdfboxMaker.java
@@ -67,7 +67,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.imageio.ImageIO;
-import java.awt.geom.AffineTransform;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -840,20 +839,6 @@ public class PdfboxMaker {
                     textObject.getBoundary().getWidth(),
                     textObject.getBoundary().getHeight());
         }
-        if (textObject.getCTM() != null) {
-            Double[] ctm = textObject.getCTM().toDouble();
-            double a = ctm[0];
-            double b = ctm[1];
-            double c = ctm[2];
-            double d = ctm[3];
-            double sx = a > 0 ? Math.signum(a) * Math.sqrt(a * a + c * c) : Math.sqrt(a * a + c * c);
-            double sy = Math.signum(d) * Math.sqrt(b * b + d * d);
-            double angel = Math.atan2(-b, d);
-            if (!(angel == 0 && a != 0 && d == 1)) {
-                fontSize = (float) (fontSize * sx);
-            }
-        }
-
         PDColor fillColor = defaultFontColor;
         CT_DrawParam ctDrawParam = resMgt.superDrawParam(textObject);
         if (ctDrawParam != null) {
@@ -870,46 +855,11 @@ public class PdfboxMaker {
         PDFont font = getFont(ctFont);
 
         List<TextCodePoint> textCodePointList = PointUtil.calPdfTextCoordinate(box.getWidth(), box.getHeight(), textObject.getBoundary(), fontSize, textObject.getTextCodes(), textObject.getCTM() != null, textObject.getCTM(), true, scale);
-        double rx = 0, ry = 0;
-        for (int i = 0; i < textCodePointList.size(); i++) {
-            TextCodePoint textCodePoint = textCodePointList.get(i);
-            if (i == 0) {
-                rx = textCodePoint.x;
-                ry = textCodePoint.y;
-            }
+        for (TextCodePoint textCodePoint : textCodePointList) {
             contentStream.saveGraphicsState();
             contentStream.beginText();
             contentStream.setNonStrokingColor(fillColor);
-            contentStream.newLineAtOffset((float) (textCodePoint.getX()), (float) (textCodePoint.getY()));
-            if (textObject.getCTM() != null) {
-                Double[] ctm = textObject.getCTM().toDouble();
-                double a = ctm[0];
-                double b = ctm[1];
-                double c = ctm[2];
-                double d = ctm[3];
-                AffineTransform transform = new AffineTransform();
-                double angel = Math.atan2(-b, d);
-                transform.rotate(angel, rx, ry);
-                contentStream.concatenate2CTM(transform);
-                if (angel == 0 && a != 0 && d == 1) {
-                    textObject.setHScale(a);
-                }
-            }
-            if (textObject.getHScale().floatValue() < 1) {
-                AffineTransform transform = new AffineTransform();
-                transform.setTransform(textObject.getHScale().floatValue(), 0, 0, 1, (1 - textObject.getHScale().floatValue()) * textCodePoint.getX(), 0);
-                contentStream.concatenate2CTM(transform);
-            }
-
-            //设置字符方向
-            if (textObject.getCharDirection() == Angle_90) {
-                contentStream.setTextMatrix(new Matrix(0, -1, 1, 0, (float) textCodePoint.getX(), (float) textCodePoint.getY()));
-            } else if (textObject.getCharDirection() == Angle_180) {
-                contentStream.setTextMatrix(new Matrix(-1, 0, 0, -1, (float) textCodePoint.getX(), (float) textCodePoint.getY()));
-            } else if (textObject.getCharDirection() == Angle_270) {
-                contentStream.setTextMatrix(new Matrix(0, 1, -1, 0, (float) textCodePoint.getX(), (float) textCodePoint.getY()));
-            }
-
+            contentStream.setTextMatrix(textMatrix(textObject, textCodePoint));
             contentStream.setFont(font, (float) converterDpi(fontSize));
             try {
                 contentStream.showText(textCodePoint.getText());
@@ -920,6 +870,49 @@ public class PdfboxMaker {
             contentStream.restoreGraphicsState();
         }
 
+    }
+
+    private Matrix textMatrix(TextObject textObject, TextCodePoint textCodePoint) {
+        double a = 1;
+        double b = 0;
+        double c = 0;
+        double d = 1;
+        if (textObject.getCTM() != null) {
+            Double[] ctm = textObject.getCTM().toDouble();
+            // Character positions already contain the complete CTM. Tm only needs its linear
+            // part, converted from OFD's downward Y axis to PDF text space's upward Y axis.
+            a = ctm[0];
+            b = -ctm[1];
+            c = -ctm[2];
+            d = ctm[3];
+        }
+
+        double charA = 1;
+        double charB = 0;
+        double charC = 0;
+        double charD = 1;
+        if (textObject.getCharDirection() == Angle_90) {
+            charA = 0;
+            charB = -1;
+            charC = 1;
+            charD = 0;
+        } else if (textObject.getCharDirection() == Angle_180) {
+            charA = -1;
+            charD = -1;
+        } else if (textObject.getCharDirection() == Angle_270) {
+            charA = 0;
+            charB = 1;
+            charC = -1;
+            charD = 0;
+        }
+
+        double hScale = textObject.getHScale();
+        double matrixA = (a * charA + c * charB) * hScale;
+        double matrixB = (b * charA + d * charB) * hScale;
+        double matrixC = a * charC + c * charD;
+        double matrixD = b * charC + d * charD;
+        return new Matrix((float) matrixA, (float) matrixB, (float) matrixC, (float) matrixD,
+                (float) textCodePoint.getX(), (float) textCodePoint.getY());
     }
 
     /**

--- a/ofdrw-converter/src/main/java/org/ofdrw/converter/utils/PointUtil.java
+++ b/ofdrw-converter/src/main/java/org/ofdrw/converter/utils/PointUtil.java
@@ -160,6 +160,12 @@ public class PointUtil {
         return new double[]{ctmX, ctmY};
     }
 
+    private static double[] ctmCalTextVector(double deltaX, double deltaY, Double[] ctm) {
+        double ctmX = deltaX * ctm[0] + deltaY * ctm[2];
+        double ctmY = deltaX * ctm[1] + deltaY * ctm[3];
+        return new double[]{ctmX, ctmY};
+    }
+
     public static List<PathPoint> calPdfPathPoint(double width, double height, ST_Box boundary, List<PathPoint> abbreviatedPoint, boolean hasCtm, ST_Array ctm, ST_Box compositeObjectBoundary, ST_Array compositeObjectCTM, boolean fixOriginToPdf) {
     	return calPdfPathPoint(width, height, boundary, abbreviatedPoint, hasCtm, ctm, compositeObjectBoundary, compositeObjectCTM, fixOriginToPdf, 1.0);
     }
@@ -260,15 +266,18 @@ public class PointUtil {
     }
 
     public static List<TextCodePoint> calPdfTextCoordinate(double width, double height, ST_Box boundary, float fontSize, List<TextCode> textCodes, boolean hasCtm, ST_Array ctm, boolean fixOriginToPdf, double scale) {
-        double x = 0, y = 0;
         List<TextCodePoint> textCodePointList = new ArrayList<>();
+        Double[] textCtm = hasCtm && ctm != null ? ctm.toDouble() : null;
         for (TextCode textCode : textCodes) {
-            x = textCode.getX() == null ? 0 : textCode.getX();
-            y = textCode.getY() == null ? 0 : textCode.getY();
-            if (hasCtm) {
-                double[] newPoint = ctmCalPoint(x, y, ctm.toDouble());
-                x = newPoint[0];
-                y = newPoint[1];
+            double localX = textCode.getX() == null ? 0 : textCode.getX();
+            double localY = textCode.getY() == null ? 0 : textCode.getY();
+            double transformedX = localX;
+            double transformedY = localY;
+            if (textCtm != null) {
+                // The TextCode origin is a point, so the CTM translation is applied once here.
+                double[] transformedPoint = ctmCalPoint(localX, localY, textCtm);
+                transformedX = transformedPoint[0];
+                transformedY = transformedPoint[1];
             }
             List<Float> deltaXList = null;
             List<Float> deltaYList = null;
@@ -289,52 +298,22 @@ public class PointUtil {
             textStr = textStr.replaceAll("&copy;", "");
             textStr = textStr.replaceAll("&apos;", "'");
             for (int i = 0; i < textStr.length(); i++) {
-                float decent = 0;
-
-//                if (textCode.getY() > 0) {
-//                    decent = fontSize - textCode.getY().floatValue();
-//                }
-                if (i > 0 && Objects.nonNull(deltaXList)) {
-                    if (hasCtm) {
-                        Double[] ctms = ctm.toDouble();
-                        double a = ctms[0].doubleValue();
-                        double b = ctms[1].doubleValue();
-                        double c = ctms[2].doubleValue();
-                        double d = ctms[3].doubleValue();
-                        double e = ctms[4].doubleValue();
-                        double f = ctms[5].doubleValue();
-                        double angel = Math.atan2(-b, d);
-                        if (angel == 0) {
-                            double[] newPoint = ctmCalPoint(deltaXList.get(i - 1), 0, ctm.toDouble());
-                            x += newPoint[0];
-                        } else {
-                            x += deltaXList.get(i - 1);
-                        }
+                if (i > 0) {
+                    double deltaX = Objects.nonNull(deltaXList) ? deltaXList.get(i - 1) : 0;
+                    double deltaY = Objects.nonNull(deltaYList) ? deltaYList.get(i - 1) : 0;
+                    localX += deltaX;
+                    localY += deltaY;
+                    if (textCtm != null) {
+                        // DeltaX and DeltaY form one vector and must not include CTM translation.
+                        double[] transformedDelta = ctmCalTextVector(deltaX, deltaY, textCtm);
+                        transformedX += transformedDelta[0];
+                        transformedY += transformedDelta[1];
                     } else {
-                        x += deltaXList.get(i - 1);
+                        transformedX = localX;
+                        transformedY = localY;
                     }
                 }
-                if (i > 0 && Objects.nonNull(deltaYList)) {
-                    if (hasCtm) {
-                        Double[] ctms = ctm.toDouble();
-                        double a = ctms[0].doubleValue();
-                        double b = ctms[1].doubleValue();
-                        double c = ctms[2].doubleValue();
-                        double d = ctms[3].doubleValue();
-                        double e = ctms[4].doubleValue();
-                        double f = ctms[5].doubleValue();
-                        double angel = Math.atan2(-b, d);
-                        if (angel == 0) {
-                            double[] newPoint = ctmCalPoint(0, deltaYList.get(i - 1), ctm.toDouble());
-                            y += newPoint[1];
-                        } else {
-                            y += deltaYList.get(i - 1);
-                        }
-                    } else {
-                        y += deltaYList.get(i - 1);
-                    }
-                }
-                double[] realPos = adjustPos(width, height, x * scale, y * scale, boundary);
+                double[] realPos = adjustPos(width, height, transformedX * scale, transformedY * scale, boundary);
                 String text = textStr.substring(i, i + 1);
                 TextCodePoint textCodePoint = new TextCodePoint(converterDpi(realPos[0]), converterDpi(fixOriginToPdf ? (height - realPos[1]) : realPos[1]), text);
                 textCodePointList.add(textCodePoint);

--- a/ofdrw-converter/src/test/java/org/ofdrw/converter/PdfboxMakerTextMatrixTest.java
+++ b/ofdrw-converter/src/test/java/org/ofdrw/converter/PdfboxMakerTextMatrixTest.java
@@ -1,0 +1,36 @@
+package org.ofdrw.converter;
+
+import org.apache.pdfbox.util.Matrix;
+import org.junit.jupiter.api.Test;
+import org.ofdrw.converter.point.TextCodePoint;
+import org.ofdrw.core.basicStructure.pageObj.layer.block.TextObject;
+import org.ofdrw.core.basicType.ST_Array;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class PdfboxMakerTextMatrixTest {
+
+    private static final float EPSILON = 0.000001f;
+
+    @Test
+    void shouldBuildPdfTextMatrixFromOfdCtm() {
+        TextObject textObject = new TextObject(1);
+        textObject.setCTM(new ST_Array(
+                2, 3,
+                4, 5,
+                10, 20
+        ));
+        textObject.setHScale(0.5);
+
+        TextCodePoint point = new TextCodePoint(123, 456, "A");
+
+        Matrix matrix = PdfboxMaker.textMatrix(textObject, point);
+
+        assertEquals(1f, matrix.getScaleX(), EPSILON);
+        assertEquals(-1.5f, matrix.getShearY(), EPSILON);
+        assertEquals(-4f, matrix.getShearX(), EPSILON);
+        assertEquals(5f, matrix.getScaleY(), EPSILON);
+        assertEquals(123f, matrix.getTranslateX(), EPSILON);
+        assertEquals(456f, matrix.getTranslateY(), EPSILON);
+    }
+}

--- a/ofdrw-converter/src/test/java/org/ofdrw/converter/utils/PointUtilTest.java
+++ b/ofdrw-converter/src/test/java/org/ofdrw/converter/utils/PointUtilTest.java
@@ -1,0 +1,56 @@
+package org.ofdrw.converter.utils;
+
+import org.junit.jupiter.api.Test;
+import org.ofdrw.converter.point.TextCodePoint;
+import org.ofdrw.core.basicType.ST_Array;
+import org.ofdrw.core.basicType.ST_Box;
+import org.ofdrw.core.text.TextCode;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.ofdrw.converter.utils.CommonUtil.converterDpi;
+
+class PointUtilTest {
+
+    private static final double EPSILON = 0.000001;
+
+    @Test
+    void ctmTranslationShouldOnlyApplyToTextOrigin() {
+        TextCode code = new TextCode()
+                .setContent("AB")
+                .setCoordinate(1d, 2d)
+                .setDeltaX(4d)
+                .setDeltaY(5d);
+
+        ST_Array ctm = new ST_Array(
+                2, 0,
+                0, 3,
+                100, 200
+        );
+        ST_Box boundary = new ST_Box(10, 20, 200, 300);
+
+        List<TextCodePoint> points = PointUtil.calPdfTextCoordinate(
+                1000,
+                1000,
+                boundary,
+                1f,
+                Collections.singletonList(code),
+                true,
+                ctm,
+                true,
+                1d
+        );
+
+        assertEquals(2, points.size());
+
+        // CTM(1, 2) = (102, 206); adding Boundary gives (112, 226).
+        assertEquals(converterDpi(112), points.get(0).getX(), EPSILON);
+        assertEquals(converterDpi(1000 - 226), points.get(0).getY(), EPSILON);
+
+        // Delta is a vector: only the CTM linear part applies, so (4, 5) -> (8, 15).
+        assertEquals(converterDpi(120), points.get(1).getX(), EPSILON);
+        assertEquals(converterDpi(1000 - 241), points.get(1).getY(), EPSILON);
+    }
+}


### PR DESCRIPTION
  ## 问题描述                                                                                                                                 
                                                                                                                                              
  PDFBox 将包含 CTM、DeltaX/DeltaY、字符方向或水平缩放的 OFD 文字转换为 PDF 时，可能出现文字位置偏移、字符间距异常以及文字矩阵不正确的问题。  
                                                                                                                                              
  ## 原因分析                                                                                                                                 
                                                                                                                                              
  主要包含两个问题：                                                                                                                          
                                                                                                                                              
  1. `TextCode` 的起始坐标属于“点”，需要应用完整 CTM，包括平移分量 `e/f`。                                                                    
  2. `DeltaX/DeltaY` 表示字符之间的“位移向量”，只能应用 CTM 的线性部分，不能应用平移分量。                                                    
                                                                                                                                              
  原实现使用同一个点变换方法处理起始坐标和 Delta，导致每个后续字符都会重复叠加 CTM 的平移分量，字符越多，位置偏移越明显。                     
                                                                                                                                              
  另外，PDFBox 端通过多次坐标移动、旋转和水平缩放组合文字矩阵，CTM 的坐标变换和 PDF `Tm` 存在重复或不一致的情况。                             
                                                                                                                                              
  ## 解决办法                                                                                                                                 
                                                                                                                                              
  - `TextCode` 起始坐标应用一次完整 CTM。                                                                                                     
  - 新增向量变换逻辑，`DeltaX/DeltaY` 只应用 CTM 的 `a/b/c/d` 线性部分。                                                                      
  - 字符坐标在 `PointUtil` 中统一计算。                                                                                                       
  - PDFBox 使用单个 PDF 文字矩阵 `Tm` 表达：                                                                                                  
    - OFD CTM 的线性变换；                                                                                                                    
    - OFD 与 PDF 的 Y 轴方向差异；                                                                                                            
    - `CharDirection`；                                                                                                                       
    - `HScale`。                                                                                                                              
  - PDF 文字矩阵中的平移位置直接使用已经计算好的字符坐标，避免重复应用 CTM 平移。                                                             
                                                                                                                                              
  ## 回归测试                                                                                                                                 
                                                                                                                                              
  新增两个回归测试：                                                                                                                          
                                                                                                                                              
  ### `PointUtilTest`                                                                                                                         
                                                                                                                                              
  构造包含缩放、平移、`DeltaX` 和 `DeltaY` 的 CTM 文字对象，验证：                                                                            
                                                                                                                                              
  - CTM 平移只应用于第一个字符的起始坐标；                                                                                                    
  - 后续字符的 Delta 只应用 CTM 线性部分；                                                                                                    
  - PDF Y 轴坐标转换正确；                                                                                                                    
  - 多字符不会重复累计 CTM 平移。                                                                                                             
                                                                                                                                              
  该测试在修复前会因为第二个字符重复叠加 CTM 平移而失败。                                                                                     
                                                                                                                                              
  ### `PdfboxMakerTextMatrixTest`                                                                                                             
                                                                                                                                              
  直接检查生成的 PDFBox `Matrix` 六个参数，验证：                                                                                             
                                                                                                                                              
  - CTM 的 `a/b/c/d` 正确写入 PDF 文字矩阵；                                                                                                  
  - OFD 向下的 Y 轴正确转换为 PDF 坐标方向；                                                                                                  
  - `HScale` 正确作用于文字矩阵；                                                                                                             

  两项回归测试均已执行通过。

  ## 验证

  使用包含 10 页内容的 OFD 样例进行 PDFBox 和 iText 转换对比：

  - 10 页均可正常导出；
  - 修复后的 PDFBox 文字位置与 iText 基本一致；
  - 原有文字坐标偏移问题消失；
  - 本测试文档较大，如果需要，我可以提供本测试文件。

  ## 其他说明

   - 项目当前 Maven Surefire 配置默认 `skipTests=true`，本 PR 未修改 `pom.xml`；
   - 本次提交采用了codex chatgpt 5.6 sol来发现问题并修改，经过回归测试和人工手动测试，如果reviewer需求ofd文档，我可以提供。