### PR TITLE
fix: 修复 PDF 图片混合模式导致的背景异常

### DIFF
--- a/ofdrw-converter/src/main/java/org/ofdrw/converter/ItextMaker.java
+++ b/ofdrw-converter/src/main/java/org/ofdrw/converter/ItextMaker.java
@@ -720,18 +720,15 @@ public class ItextMaker {
         }
         pdfCanvas.saveState();
 
-        // 设置图片混合模式为 Multiply（正片叠底），防止图片遮挡文字
-        // 参考 AWTMaker 使用 AlphaComposite.SRC_ATOP 的效果
-        PdfExtGState extGState = new PdfExtGState();
-        extGState.setBlendMode(PdfExtGState.BM_MULTIPLY);
-
-        // 处理图片透明度
+        // OFD image objects use normal source-over compositing. Applying Multiply
+        // changes opaque white pixels into transparent-looking pixels and exposes
+        // content that should have been covered by the image.
         Integer alpha = imageObject.getAlpha();
         if (alpha != null && alpha < 255) {
+            PdfExtGState extGState = new PdfExtGState();
             extGState.setFillOpacity(alpha * 1.0f / 255);
+            pdfCanvas.setExtGState(extGState);
         }
-
-        pdfCanvas.setExtGState(extGState);
 
         ImageData image = ImageDataFactory.create(imageByteArray);
         if (annotBox != null && !isSameBox(annotBox, imageObject.getBoundary())) {

--- a/ofdrw-converter/src/main/java/org/ofdrw/converter/PdfboxMaker.java
+++ b/ofdrw-converter/src/main/java/org/ofdrw/converter/PdfboxMaker.java
@@ -757,18 +757,15 @@ public class PdfboxMaker {
         }
         contentStream.saveGraphicsState();
 
-        // 设置图片混合模式为 Multiply（正片叠底），防止图片遮挡文字
-        // 参考 AWTMaker 使用 AlphaComposite.SRC_ATOP 的效果
-        PDExtendedGraphicsState graphicsState = new PDExtendedGraphicsState();
-        graphicsState.setBlendMode(org.apache.pdfbox.pdmodel.graphics.blend.BlendMode.MULTIPLY);
-
-        // 处理图片透明度
+        // OFD image objects use normal source-over compositing. Applying Multiply
+        // changes opaque white pixels into transparent-looking pixels and exposes
+        // content that should have been covered by the image.
         Integer alpha = imageObject.getAlpha();
         if (alpha != null && alpha < 255) {
+            PDExtendedGraphicsState graphicsState = new PDExtendedGraphicsState();
             graphicsState.setNonStrokingAlphaConstant(alpha * 1.0f / 255);
+            contentStream.setGraphicsStateParameters(graphicsState);
         }
-
-        contentStream.setGraphicsStateParameters(graphicsState);
 
         // 根据图片格式决定图片使用哪种创建方式
         PDImageXObject pdfImageObject;

--- a/ofdrw-converter/src/test/java/org/ofdrw/converter/export/ImageBlendModeExportTest.java
+++ b/ofdrw-converter/src/test/java/org/ofdrw/converter/export/ImageBlendModeExportTest.java
@@ -1,0 +1,83 @@
+package org.ofdrw.converter.export;
+
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.rendering.PDFRenderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.ofdrw.graphics2d.OFDGraphicsDocument;
+import org.ofdrw.graphics2d.OFDPageGraphics2D;
+
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ImageBlendModeExportTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void itextUsesNormalBlendModeForOpaqueImages() throws Exception {
+        assertOpaqueImageCoversEarlierContent("itext", PDFExporterIText::new);
+    }
+
+    @Test
+    void pdfboxUsesNormalBlendModeForOpaqueImages() throws Exception {
+        assertOpaqueImageCoversEarlierContent("pdfbox", PDFExporterPDFBox::new);
+    }
+
+    private void assertOpaqueImageCoversEarlierContent(String name, ExporterFactory factory) throws Exception {
+        Path ofd = tempDir.resolve(name + ".ofd");
+        Path pdf = tempDir.resolve(name + ".pdf");
+        createOverlappingImageDocument(ofd);
+
+        try (OFDExporter exporter = factory.create(ofd, pdf)) {
+            exporter.export();
+        }
+
+        try (PDDocument document = PDDocument.load(pdf.toFile())) {
+            BufferedImage page = new PDFRenderer(document).renderImageWithDPI(0, 144);
+            Color background = new Color(page.getRGB(page.getWidth() / 10, page.getHeight() / 10));
+            Color covered = new Color(page.getRGB(page.getWidth() / 2, page.getHeight() / 2));
+
+            assertTrue(isAlmostBlack(background), "The lower black layer was not rendered");
+            assertTrue(isAlmostWhite(covered),
+                    "An opaque white image must cover earlier content, but was " + covered);
+        }
+    }
+
+    private void createOverlappingImageDocument(Path destination) throws IOException {
+        BufferedImage whiteImage = new BufferedImage(20, 20, BufferedImage.TYPE_INT_RGB);
+        Graphics2D imageGraphics = whiteImage.createGraphics();
+        try {
+            imageGraphics.setColor(Color.WHITE);
+            imageGraphics.fillRect(0, 0, whiteImage.getWidth(), whiteImage.getHeight());
+        } finally {
+            imageGraphics.dispose();
+        }
+
+        try (OFDGraphicsDocument document = new OFDGraphicsDocument(destination)) {
+            OFDPageGraphics2D page = document.newPage(100, 100);
+            page.setColor(Color.BLACK);
+            page.fillRect(0, 0, 100, 100);
+            page.drawImage(whiteImage, 20, 20, 60, 60, null);
+        }
+    }
+
+    private boolean isAlmostBlack(Color color) {
+        return color.getRed() < 20 && color.getGreen() < 20 && color.getBlue() < 20;
+    }
+
+    private boolean isAlmostWhite(Color color) {
+        return color.getRed() > 235 && color.getGreen() > 235 && color.getBlue() > 235;
+    }
+
+    @FunctionalInterface
+    private interface ExporterFactory {
+        OFDExporter create(Path ofd, Path pdf) throws IOException;
+    }
+}


### PR DESCRIPTION
  ## 问题原因                                                                                                                                 
                                                                                                                                              
  iText 和 PDFBox 导出器在绘制图片时，统一强制使用了 `Multiply`（正片叠底）混合模式。                                                         
                                                                                                                                              
  该模式会导致图片中的白色像素无法正常遮盖之前绘制的文字或图形，使底层内容透出，从而出现图片背景异常、内容重影等问题。                        
                                                                                                                                              
  ## 解决办法
                                                                                                                                              
  - 移除 iText 导出器中强制设置的 `Multiply` 混合模式。                                                                                       
  - 移除 PDFBox 导出器中强制设置的 `Multiply` 混合模式。                                                                                      
  - 图片使用 PDF 默认的普通混合方式进行绘制。                                                                                                 
  - 仅当 OFD 图片的透明度小于 255 时创建并设置图形状态。                                                                                      
  - 保留原有的图片透明度处理逻辑。                                                                                                            
                                                                                                                                              
  ## 回归测试                                                                                                                                 
                                                                                                                                              
  为 iText 和 PDFBox 两种导出器分别增加了回归测试。                                                                                           
                                                                                                                                              
  测试过程：                                                                                                                                  
                                                                                                                                              
  1. 创建一个以黑色图形为底层的 OFD 页面。                                                                                                    
  2. 在黑色区域上绘制一张不透明的白色图片。                                                                                                   
  3. 分别使用 iText 和 PDFBox 转换为 PDF。                                                                                                    
  4. 将生成的 PDF 页面渲染为图片。                                                                                                            
  5. 验证未被图片覆盖的区域仍为黑色。                                                                                                         
  6. 验证图片覆盖区域为白色，且底层内容没有透出。