### PR TITLE
fix: 修复 PDF 路径裁剪边界偏移

### DIFF
--- a/ofdrw-converter/src/main/java/org/ofdrw/converter/ItextMaker.java
+++ b/ofdrw-converter/src/main/java/org/ofdrw/converter/ItextMaker.java
@@ -629,14 +629,17 @@ public class ItextMaker {
         List<CT_Clip> clips = pathObject.getClips().getClips();
         for (int k = 0; k < clips.size(); k++) {
             CT_Clip clip = clips.get(k);
+            boolean hasPath = false;
             for (Area area : clip.getAreas()) {
                 Element elePath = area.getOFDElement("Path");
+                if (elePath == null) {
+                    continue;
+                }
                 CT_Path path = new CT_Path(elePath);
                 List<PathPoint> points = PointUtil.calPdfPathPoint(box.getWidth(), box.getHeight(),
-                        pathObject.getBoundary(),
+                        PointUtil.combineBoundary(pathObject.getBoundary(), path.getBoundary()),
                         PointUtil.convertPathAbbreviatedDatatoPoint(path.getAbbreviatedData()), area.getCTM() != null,
                         area.getCTM(), null, null, true, 1.0);
-                pdfCanvas.clip();
                 for (int i = 0; i < points.size(); i++) {
                     PathPoint pathPoint = points.get(i);
                     if (pathPoint.type.equals("M") || pathPoint.type.equals("S")) {
@@ -652,6 +655,10 @@ public class ItextMaker {
                         pdfCanvas.closePath();
                     }
                 }
+                hasPath = true;
+            }
+            if (hasPath) {
+                pdfCanvas.clip();
                 pdfCanvas.endPath();
             }
         }

--- a/ofdrw-converter/src/main/java/org/ofdrw/converter/PdfboxMaker.java
+++ b/ofdrw-converter/src/main/java/org/ofdrw/converter/PdfboxMaker.java
@@ -661,12 +661,15 @@ public class PdfboxMaker {
         List<CT_Clip> clips = pathObject.getClips().getClips();
         for (int k = 0; k < clips.size(); k++) {
             CT_Clip clip = clips.get(k);
-            contentStream.clip();
+            boolean hasPath = false;
             for (Area area : clip.getAreas()) {
                 Element elePath = area.getOFDElement("Path");
+                if (elePath == null) {
+                    continue;
+                }
                 CT_Path path = new CT_Path(elePath);
                 List<PathPoint> points = PointUtil.calPdfPathPoint(box.getWidth(), box.getHeight(),
-                        pathObject.getBoundary(),
+                        PointUtil.combineBoundary(pathObject.getBoundary(), path.getBoundary()),
                         PointUtil.convertPathAbbreviatedDatatoPoint(path.getAbbreviatedData()), area.getCTM() != null,
                         area.getCTM(), null, null, true, 1.0);
                 for (int i = 0; i < points.size(); i++) {
@@ -683,9 +686,12 @@ public class PdfboxMaker {
                     } else if (pathPoint.type.equals("C")) {
                         contentStream.closePath();
                     }
-                }   
+                }
+                hasPath = true;
             }
-            contentStream.clip();
+            if (hasPath) {
+                contentStream.clip();
+            }
         }
     }
 

--- a/ofdrw-converter/src/main/java/org/ofdrw/converter/utils/PointUtil.java
+++ b/ofdrw-converter/src/main/java/org/ofdrw/converter/utils/PointUtil.java
@@ -154,6 +154,27 @@ public class PointUtil {
         return new double[]{realX, realY};
     }
 
+    /**
+     * 将子图元的外接矩形转换到父图元坐标系。
+     *
+     * @param parentBoundary 父图元外接矩形
+     * @param childBoundary  子图元在父图元坐标系中的外接矩形
+     * @return 子图元在页面坐标系中的外接矩形
+     */
+    public static ST_Box combineBoundary(ST_Box parentBoundary, ST_Box childBoundary) {
+        if (parentBoundary == null) {
+            return childBoundary;
+        }
+        if (childBoundary == null) {
+            return parentBoundary;
+        }
+        return new ST_Box(
+                parentBoundary.getTopLeftX() + childBoundary.getTopLeftX(),
+                parentBoundary.getTopLeftY() + childBoundary.getTopLeftY(),
+                childBoundary.getWidth(),
+                childBoundary.getHeight());
+    }
+
     public static double[] ctmCalPoint(double x, double y, Double[] ctm) {
         double ctmX = x * ctm[0] + y * ctm[2] + 1 * ctm[4];
         double ctmY = x * ctm[1] + y * ctm[3] + 1 * ctm[5];

--- a/ofdrw-converter/src/test/java/org/ofdrw/converter/utils/PointUtilTest.java
+++ b/ofdrw-converter/src/test/java/org/ofdrw/converter/utils/PointUtilTest.java
@@ -1,0 +1,32 @@
+package org.ofdrw.converter.utils;
+
+import org.junit.jupiter.api.Test;
+import org.ofdrw.core.basicType.ST_Box;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class PointUtilTest {
+
+    @Test
+    void combineBoundaryShouldIncludeNestedClipPathOffset() {
+        ST_Box objectBoundary = new ST_Box(89.5, 3.5, 31, 21);
+        ST_Box clipPathBoundary = new ST_Box(0.5, 0.5, 30, 20);
+
+        ST_Box actual = PointUtil.combineBoundary(objectBoundary, clipPathBoundary);
+
+        assertEquals(90, actual.getTopLeftX());
+        assertEquals(4, actual.getTopLeftY());
+        assertEquals(30, actual.getWidth());
+        assertEquals(20, actual.getHeight());
+        assertEquals(89.5, objectBoundary.getTopLeftX());
+        assertEquals(3.5, objectBoundary.getTopLeftY());
+    }
+
+    @Test
+    void combineBoundaryShouldKeepParentWhenNestedBoundaryIsMissing() {
+        ST_Box objectBoundary = new ST_Box(10, 20, 30, 40);
+
+        assertSame(objectBoundary, PointUtil.combineBoundary(objectBoundary, null));
+    }
+}


### PR DESCRIPTION
 ## 问题描述                                                                                                                                 
                                                                                                                                              
  部分 OFD 文件转换为 PDF 时，带有裁剪区域的路径会出现边缘被裁切的问题。                                                                      
                                                                                                                                              
  例如火车票中的红色印章，在转换后的 PDF 中右侧和底部会被裁切约 0.5 mm，而 OFD 阅读器及 SVG 转换结果显示正常。                                
                                                                                                                                              
  该问题同时影响 iText 和 PDFBox 转换后端。                                                                                                   
                                                                                                                                              
  ## 问题原因                                                                                                                                 
                                                                                                                                              
  裁剪路径位于图元对象的局部坐标系中，但转换时只使用了外层 `PathObject` 的 `Boundary`，没有叠加内部裁剪路径自身的 `Boundary` 偏移。           
                                                                                                                                              
  例如：                                                                                                                                      
                                                                                                                                              
  - 外层图元 Boundary：`89.5 3.5 31 21`                                                                                                       
  - 裁剪路径 Boundary：`0.5 0.5 30 20`                                                                                                        
  - 正确的裁剪路径起点应为：`90 4`                                                                                                            
                                                                                                                                              
  原实现将裁剪路径错误地放置在 `89.5 3.5`，导致路径右侧和底部被裁切。                                                                         
                                                                                                                                              
  此外，iText 和 PDFBox 的裁剪操作执行顺序不规范，可能导致不同 PDF 渲染器产生不一致的结果。                                                   
                                                                                                                                              
  ## 解决办法                                                                                                                                 
                                                                                                                                              
  - 增加 `PointUtil.combineBoundary`，将外层图元和内部裁剪路径的 Boundary 偏移正确叠加。                                                      
  - iText 和 PDFBox 统一使用合成后的裁剪路径坐标。                                                                                            
  - 调整裁剪操作顺序，先构造完整路径，再执行 PDF 裁剪操作。                                                                                   
  - 同一个 `CT_Clip` 中的多个 `Area` 先组成并集，再与其他 `CT_Clip` 求交。                                                                    
  - 忽略当前不支持的非 Path 裁剪对象，避免空路径影响已有内容。                                                                                
                                                                                                                                              
  ## 回归测试                                                                                                                                 
                                                                                                                                              
  新增 `PointUtilTest`，验证：                                                                                                                
                                                                                                                                              
  1. 外层 Boundary 与内部裁剪路径 Boundary 的偏移能够正确叠加。                                                                               
  2. 内部裁剪路径没有 Boundary 时保持原有坐标行为。                                                                                           
  3. 合成边界时不会修改原始外层 Boundary。                                                                                                    
                                                                                                                                              
  同时执行了现有的 iText 和 PDFBox Path 裁剪测试，测试均通过。                                                                                
                                                                                                                                              
  使用火车票 OFD 进行 600 DPI 渲染检查，修复后 iText 和 PDFBox 生成的印章右侧及底部均显示完整。