### PR TITLE
fix: 修复 iText 导出倾斜文字下边缘被裁切

### DIFF
--- a/ofdrw-converter/src/main/java/org/ofdrw/converter/ItextMaker.java
+++ b/ofdrw-converter/src/main/java/org/ofdrw/converter/ItextMaker.java
@@ -85,6 +85,9 @@ import static org.ofdrw.core.text.text.Direction.*;
  */
 public class ItextMaker {
 
+    // 与 AWT 渲染保持一致，避免倾斜或描边字形超出紧边界时被裁切。
+    private static final double TEXT_CLIP_MARGIN = 1d;
+
     private Map<String, FontWrapper<PdfFont>> fontCache = new HashMap<>();
 
     private final OFDReader ofdReader;
@@ -910,11 +913,7 @@ public class ItextMaker {
 
         // 创建矩形对象, 指定文字绘制区域
         ST_Box boundary = textObject.getBoundary();
-        Rectangle rectangle = new Rectangle(
-                (float) converterDpi(boundary.getTopLeftX()),
-                (float) converterDpi(box.getHeight() - boundary.getTopLeftY() - boundary.getHeight()),
-                (float) converterDpi(boundary.getWidth()),
-                (float) converterDpi(boundary.getHeight()));
+        Rectangle rectangle = textClipRectangle(box, boundary);
 
         double rx = 0, ry = 0;
         for (int i = 0; i < textCodePointList.size(); i++) {
@@ -1032,6 +1031,15 @@ public class ItextMaker {
             pdfCanvas.endText();
             pdfCanvas.restoreState();
         }
+    }
+
+    static Rectangle textClipRectangle(ST_Box pageBox, ST_Box boundary) {
+        return new Rectangle(
+                (float) converterDpi(boundary.getTopLeftX() - TEXT_CLIP_MARGIN),
+                (float) converterDpi(pageBox.getHeight() - boundary.getTopLeftY()
+                        - boundary.getHeight() - TEXT_CLIP_MARGIN),
+                (float) converterDpi(boundary.getWidth() + TEXT_CLIP_MARGIN * 2),
+                (float) converterDpi(boundary.getHeight() + TEXT_CLIP_MARGIN * 2));
     }
 
     /**

--- a/ofdrw-converter/src/test/java/org/ofdrw/converter/ItextMakerTest.java
+++ b/ofdrw-converter/src/test/java/org/ofdrw/converter/ItextMakerTest.java
@@ -1,0 +1,25 @@
+package org.ofdrw.converter;
+
+import com.itextpdf.kernel.geom.Rectangle;
+import org.junit.jupiter.api.Test;
+import org.ofdrw.core.basicType.ST_Box;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.ofdrw.converter.utils.CommonUtil.converterDpi;
+
+class ItextMakerTest {
+
+    @Test
+    void textClipRectangleShouldKeepOneMillimeterMargin() {
+        ST_Box pageBox = new ST_Box(0, 0, 210, 297);
+        ST_Box boundary = new ST_Box(85.682663, 64.515999, 22.013334, 4.233333);
+
+        Rectangle clip = ItextMaker.textClipRectangle(pageBox, boundary);
+
+        assertEquals(converterDpi(boundary.getTopLeftX() - 1), clip.getX(), 0.001);
+        assertEquals(converterDpi(pageBox.getHeight() - boundary.getTopLeftY()
+                - boundary.getHeight() - 1), clip.getY(), 0.001);
+        assertEquals(converterDpi(boundary.getWidth() + 2), clip.getWidth(), 0.001);
+        assertEquals(converterDpi(boundary.getHeight() + 2), clip.getHeight(), 0.001);
+    }
+}


### PR DESCRIPTION
  ## 问题描述                                                                                                                                 
                                                                                                                                              
  使用 iText 将部分 OFD 文档转换为 PDF 时，文字绘制区域会严格按照                                                                             
  `TextObject` 的 `Boundary` 进行裁剪。                                                                                                       
                                                                                                                                              
  当文字为倾斜字体或带有描边效果时，实际字形可能略微超出该边界，                                                                              
  导致转换后的 PDF 中出现文字边缘被裁切的问题。                                                                                               
                                                                                                                                              
  倾斜文字的下边缘显示不完整。                                                               
                                                                                                                                              
  ## 原因分析                                                                                                                                 
                                                                                                                                              
  原实现直接使用文字对象的 `Boundary` 创建 iText 裁剪矩形，没有预留字形扩展空间。                                                             
                                                                                                                                              
  倾斜、描边等字形的实际绘制范围可能超出字体的紧边界，因此超出的部分会被裁剪掉。                                                              
                                                                                                                                              
  ## 修改内容                                                                                                                                 
                                                                                                                                              
  - 仅调整文字裁剪范围，不改变文字的位置、大小和排版。
  - 增加单元测试，验证裁剪区域在四个方向均保留 1 mm 的余量。
