### PR TITLE
fix: 修复旧版 Foxit OFD 路径渲染

### DIFF
--- a/ofdrw-converter/src/main/java/org/ofdrw/converter/ItextMaker.java
+++ b/ofdrw-converter/src/main/java/org/ofdrw/converter/ItextMaker.java
@@ -505,21 +505,14 @@ public class ItextMaker {
             pdfCanvas.setStrokeColor(defaultStrokeColor);
         }
 
+        boolean legacyAbsolutePath = sealBox == null && annotBox == null && compositeObjectBoundary == null
+                && PointUtil.isLegacyAbsolutePath(box.getWidth(), box.getHeight(), pathObject.getBoundary(),
+                PointUtil.convertPathAbbreviatedDatatoPoint(pathObject.getAbbreviatedData()),
+                pathObject.getCTM() != null, pathObject.getCTM());
         float lineWidth = defaultLineWidth;
         if (pathObject.getLineWidth() != null && pathObject.getLineWidth() > 0) {
-            lineWidth = Double.valueOf(converterDpi(pathObject.getLineWidth()) * scale).floatValue();
-        }
-        if (pathObject.getCTM() != null && pathObject.getLineWidth() != null) {
-            Double[] ctm = pathObject.getCTM().toDouble();
-            double a = ctm[0];
-            double b = ctm[1];
-            double c = ctm[2];
-            double d = ctm[3];
-            double e = ctm[4];
-            double f = ctm[5];
-            double sx = Math.signum(a) * Math.sqrt(a * a + c * c);
-            double sy = Math.signum(d) * Math.sqrt(b * b + d * d);
-            lineWidth = (float) (lineWidth * sx);
+            lineWidth = (float) PointUtil.calPdfPathLineWidth(pathObject.getLineWidth(), scale,
+                    legacyAbsolutePath, pathObject.getCTM());
         }
         pdfCanvas.setLineWidth(lineWidth);
         if (pathObject.getStroke()) {

--- a/ofdrw-converter/src/main/java/org/ofdrw/converter/PdfboxMaker.java
+++ b/ofdrw-converter/src/main/java/org/ofdrw/converter/PdfboxMaker.java
@@ -484,23 +484,16 @@ public class PdfboxMaker {
             contentStream.setStrokingColor(defaultStrokeColor);
         }
 
+        boolean legacyAbsolutePath = sealBox == null && annotBox == null && compositeObjectBoundary == null
+                && PointUtil.isLegacyAbsolutePath(box.getWidth(), box.getHeight(), pathObject.getBoundary(),
+                PointUtil.convertPathAbbreviatedDatatoPoint(pathObject.getAbbreviatedData()),
+                pathObject.getCTM() != null, pathObject.getCTM());
         float lineWidth = defaultLineWidth;
         if (pathObject.getLineWidth() != null && pathObject.getLineWidth() > 0) {
-            lineWidth = Double.valueOf(converterDpi(pathObject.getLineWidth()) * scale).floatValue();
+            lineWidth = (float) PointUtil.calPdfPathLineWidth(pathObject.getLineWidth(), scale,
+                    legacyAbsolutePath, pathObject.getCTM());
         }
         contentStream.setLineWidth(lineWidth);
-        if (pathObject.getCTM() != null && pathObject.getLineWidth() != null) {
-            Double[] ctm = pathObject.getCTM().toDouble();
-            double a = ctm[0];
-            double b = ctm[1];
-            double c = ctm[2];
-            double d = ctm[3];
-            double e = ctm[4];
-            double f = ctm[5];
-            double sx = Math.signum(a) * Math.sqrt(a * a + c * c);
-            double sy = Math.signum(d) * Math.sqrt(b * b + d * d);
-            lineWidth = (float) (lineWidth * sx);
-        }
         if (pathObject.getStroke()) {
             if (compositeObjectAlpha != null) {
                 PDExtendedGraphicsState graphicsState = new PDExtendedGraphicsState();
@@ -517,9 +510,6 @@ public class PdfboxMaker {
             contentStream.setLineCapStyle(pathObject.getCap().ordinal());
             contentStream.setMiterLimit(pathObject.getMiterLimit().floatValue());
             path(contentStream, box, sealBox, annotBox, pathObject, compositeObjectBoundary, compositeObjectCTM);
-            if (pathObject.getLineWidth() != null && pathObject.getLineWidth() > 0) {
-                contentStream.setLineWidth((float) converterDpi(pathObject.getLineWidth()));
-            }
             PDShading shading = parseShading(strokeColor, box, pathObject);
             if (shading != null) {
                 contentStream.clip();

--- a/ofdrw-converter/src/main/java/org/ofdrw/converter/utils/PointUtil.java
+++ b/ofdrw-converter/src/main/java/org/ofdrw/converter/utils/PointUtil.java
@@ -28,6 +28,12 @@ public class PointUtil {
     private final static Logger logger = LoggerFactory.getLogger(PointUtil.class);
 
     /**
+     * Early Foxit OFD files store path coordinates in a 300 DPI device space.
+     */
+    private static final double LEGACY_PATH_DPI = 300d;
+    private static final double LEGACY_PATH_MM_SCALE = 25.4d / LEGACY_PATH_DPI;
+
+    /**
      * 解析压缩路径为点坐标
      *
      * @param abbreviatedData 压缩路径
@@ -187,24 +193,152 @@ public class PointUtil {
         return new double[]{ctmX, ctmY};
     }
 
+    /**
+     * Detects the absolute 300 DPI path coordinates used by pre-standard Foxit OFD files.
+     * Their declared CTM places the complete path outside its Boundary, while interpreting
+     * the raw coordinates as 300 DPI device coordinates places it inside the Boundary.
+     */
+    public static boolean isLegacyAbsolutePath(double width, double height, ST_Box boundary,
+                                               List<PathPoint> points, boolean hasCtm, ST_Array ctm) {
+        if (boundary == null || !hasCtm || ctm == null || points == null || points.isEmpty()) {
+            return false;
+        }
+
+        PathBounds raw = pathBounds(points, null, 1d);
+        if (raw == null || (raw.maxAbsX() <= width * 2 && raw.maxAbsY() <= height * 2)) {
+            return false;
+        }
+
+        PathBounds standard = pathBounds(points, ctm.toDouble(), 1d);
+        if (standard != null && standard.intersects(0, 0, boundary.getWidth(), boundary.getHeight())) {
+            return false;
+        }
+
+        PathBounds legacy = pathBounds(points, null, LEGACY_PATH_MM_SCALE);
+        double tolerance = Math.max(0.5d, Math.max(boundary.getWidth(), boundary.getHeight()) * 0.1d);
+        return legacy != null && legacy.inside(
+                boundary.getTopLeftX() - tolerance,
+                boundary.getTopLeftY() - tolerance,
+                boundary.getTopLeftX() + boundary.getWidth() + tolerance,
+                boundary.getTopLeftY() + boundary.getHeight() + tolerance);
+    }
+
+    /**
+     * Converts an OFD path line width to PDF points.
+     */
+    public static double calPdfPathLineWidth(double lineWidth, double scale,
+                                             boolean legacyAbsolutePath, ST_Array ctm) {
+        if (legacyAbsolutePath) {
+            // The legacy Foxit value is already expressed in PDF user units (points).
+            return lineWidth * scale;
+        }
+        double result = converterDpi(lineWidth) * scale;
+        if (ctm != null) {
+            Double[] values = ctm.toDouble();
+            double sx = Math.signum(values[0])
+                    * Math.sqrt(values[0] * values[0] + values[2] * values[2]);
+            result *= sx;
+        }
+        return result;
+    }
+
+    private static PathBounds pathBounds(List<PathPoint> points, Double[] ctm, double scale) {
+        PathBounds bounds = new PathBounds();
+        for (PathPoint point : points) {
+            switch (point.type) {
+                case "M":
+                case "L":
+                case "S":
+                    bounds.add(point.x1, point.y1, ctm, scale);
+                    break;
+                case "B":
+                    bounds.add(point.x1, point.y1, ctm, scale);
+                    bounds.add(point.x2, point.y2, ctm, scale);
+                    bounds.add(point.x3, point.y3, ctm, scale);
+                    break;
+                case "Q":
+                    bounds.add(point.x1, point.y1, ctm, scale);
+                    bounds.add(point.x2, point.y2, ctm, scale);
+                    break;
+                case "A":
+                    bounds.add(point.x, point.y, ctm, scale);
+                    break;
+                default:
+                    break;
+            }
+        }
+        return bounds.empty ? null : bounds;
+    }
+
+    private static class PathBounds {
+        private boolean empty = true;
+        private double minX;
+        private double minY;
+        private double maxX;
+        private double maxY;
+
+        private void add(double x, double y, Double[] ctm, double scale) {
+            if (ctm != null) {
+                double[] transformed = ctmCalPoint(x, y, ctm);
+                x = transformed[0];
+                y = transformed[1];
+            }
+            x *= scale;
+            y *= scale;
+            if (empty) {
+                minX = maxX = x;
+                minY = maxY = y;
+                empty = false;
+                return;
+            }
+            minX = Math.min(minX, x);
+            minY = Math.min(minY, y);
+            maxX = Math.max(maxX, x);
+            maxY = Math.max(maxY, y);
+        }
+
+        private double maxAbsX() {
+            return Math.max(Math.abs(minX), Math.abs(maxX));
+        }
+
+        private double maxAbsY() {
+            return Math.max(Math.abs(minY), Math.abs(maxY));
+        }
+
+        private boolean intersects(double left, double top, double right, double bottom) {
+            return maxX >= left && minX <= right && maxY >= top && minY <= bottom;
+        }
+
+        private boolean inside(double left, double top, double right, double bottom) {
+            return minX >= left && maxX <= right && minY >= top && maxY <= bottom;
+        }
+    }
+
     public static List<PathPoint> calPdfPathPoint(double width, double height, ST_Box boundary, List<PathPoint> abbreviatedPoint, boolean hasCtm, ST_Array ctm, ST_Box compositeObjectBoundary, ST_Array compositeObjectCTM, boolean fixOriginToPdf) {
     	return calPdfPathPoint(width, height, boundary, abbreviatedPoint, hasCtm, ctm, compositeObjectBoundary, compositeObjectCTM, fixOriginToPdf, 1.0);
     }
     
     public static List<PathPoint> calPdfPathPoint(double width, double height, ST_Box boundary, List<PathPoint> abbreviatedPoint, boolean hasCtm, ST_Array ctm, ST_Box compositeObjectBoundary, ST_Array compositeObjectCTM, boolean fixOriginToPdf, double scale) {
         List<PathPoint> pointList = new ArrayList<>();
+        boolean legacyAbsolutePath = scale == 1d && compositeObjectBoundary == null
+                && isLegacyAbsolutePath(width, height, boundary, abbreviatedPoint, hasCtm, ctm);
         for (PathPoint point : abbreviatedPoint) {
             if (point.type.equals("M") || point.type.equals("L") || point.type.equals("C") || point.type.equals("S")) {
                 double x = 0, y = 0;
                 x = point.x1;
                 y = point.y1;
 
-                if (hasCtm) {
+                if (legacyAbsolutePath) {
+                    x *= LEGACY_PATH_MM_SCALE;
+                    y *= LEGACY_PATH_MM_SCALE;
+                } else if (hasCtm) {
                     double[] newPoint = ctmCalPoint(x, y, ctm.toDouble());
                     x = newPoint[0];
                     y = newPoint[1];
                 }
-                double[] realPos = adjustPos(width, height, x * scale, y * scale, boundary);
+                double[] realPos = legacyAbsolutePath
+                        ? new double[]{x, y}
+                        : adjustPos(width, height, x * scale, y * scale, boundary);
                 point.x1 = (float) converterDpi(realPos[0]);
                 point.y1 = (float) converterDpi(fixOriginToPdf ? (height - realPos[1]) : realPos[1]);
                 if (compositeObjectBoundary != null) {
@@ -220,7 +354,14 @@ public class PointUtil {
                 double x1 = point.x1, y1 = point.y1;
                 double x2 = point.x2, y2 = point.y2;
                 double x3 = point.x3, y3 = point.y3;
-                if (hasCtm) {
+                if (legacyAbsolutePath) {
+                    x1 *= LEGACY_PATH_MM_SCALE;
+                    y1 *= LEGACY_PATH_MM_SCALE;
+                    x2 *= LEGACY_PATH_MM_SCALE;
+                    y2 *= LEGACY_PATH_MM_SCALE;
+                    x3 *= LEGACY_PATH_MM_SCALE;
+                    y3 *= LEGACY_PATH_MM_SCALE;
+                } else if (hasCtm) {
                     double[] newPoint = ctmCalPoint(x1, y1, ctm.toDouble());
                     x1 = newPoint[0];
                     y1 = newPoint[1];
@@ -231,13 +372,19 @@ public class PointUtil {
                     x3 = newPoint[0];
                     y3 = newPoint[1];
                 }
-                double[] realPos = adjustPos(width, height, x1 * scale, y1 * scale, boundary);
+                double[] realPos = legacyAbsolutePath
+                        ? new double[]{x1, y1}
+                        : adjustPos(width, height, x1 * scale, y1 * scale, boundary);
                 x1 = realPos[0];
                 y1 = realPos[1];
-                realPos = adjustPos(width, height, x2 * scale, y2 * scale, boundary);
+                realPos = legacyAbsolutePath
+                        ? new double[]{x2, y2}
+                        : adjustPos(width, height, x2 * scale, y2 * scale, boundary);
                 x2 = realPos[0];
                 y2 = realPos[1];
-                realPos = adjustPos(width, height, x3 * scale, y3 * scale, boundary);
+                realPos = legacyAbsolutePath
+                        ? new double[]{x3, y3}
+                        : adjustPos(width, height, x3 * scale, y3 * scale, boundary);
                 x3 = realPos[0];
                 y3 = realPos[1];
                 PathPoint realPoint = new PathPoint("B", (float) converterDpi(x1), (float) converterDpi(fixOriginToPdf ? (height - y1) : y1),
@@ -247,7 +394,12 @@ public class PointUtil {
             } else if (point.type.equals("Q")) {
                 double x1 = point.x1, y1 = point.y1;
                 double x2 = point.x2, y2 = point.y2;
-                if (hasCtm) {
+                if (legacyAbsolutePath) {
+                    x1 *= LEGACY_PATH_MM_SCALE;
+                    y1 *= LEGACY_PATH_MM_SCALE;
+                    x2 *= LEGACY_PATH_MM_SCALE;
+                    y2 *= LEGACY_PATH_MM_SCALE;
+                } else if (hasCtm) {
                     double[] newPoint = ctmCalPoint(x1, y1, ctm.toDouble());
                     x1 = newPoint[0];
                     y1 = newPoint[1];
@@ -255,10 +407,14 @@ public class PointUtil {
                     x2 = newPoint[0];
                     y2 = newPoint[1];
                 }
-                double[] realPos = adjustPos(width, height, x1 * scale, y1 * scale, boundary);
+                double[] realPos = legacyAbsolutePath
+                        ? new double[]{x1, y1}
+                        : adjustPos(width, height, x1 * scale, y1 * scale, boundary);
                 x1 = realPos[0];
                 y1 = realPos[1];
-                realPos = adjustPos(width, height, x2 * scale, y2 * scale, boundary);
+                realPos = legacyAbsolutePath
+                        ? new double[]{x2, y2}
+                        : adjustPos(width, height, x2 * scale, y2 * scale, boundary);
                 x2 = realPos[0];
                 y2 = realPos[1];
                 PathPoint realPoint = new PathPoint("Q", (float) converterDpi(x1), (float) converterDpi(fixOriginToPdf ? (height - y1) : y1),
@@ -269,12 +425,19 @@ public class PointUtil {
                 double rx = point.rx, ry = point.ry;
                 float rotation = point.rotation, arc = point.arc, sweep = point.sweep;
                 double x = point.x, y = point.y;
-                if (hasCtm) {
+                if (legacyAbsolutePath) {
+                    rx *= LEGACY_PATH_MM_SCALE;
+                    ry *= LEGACY_PATH_MM_SCALE;
+                    x *= LEGACY_PATH_MM_SCALE;
+                    y *= LEGACY_PATH_MM_SCALE;
+                } else if (hasCtm) {
                     double[] newPoint = ctmCalPoint(x, y, ctm.toDouble());
                     x = newPoint[0];
                     y = newPoint[1];
                 }
-                double[] realPos = adjustPos(width, height, x * scale, y * scale, boundary);
+                double[] realPos = legacyAbsolutePath
+                        ? new double[]{x, y}
+                        : adjustPos(width, height, x * scale, y * scale, boundary);
                 x = realPos[0];
                 y = realPos[1];
                 PathPoint realPoint = new PathPoint("A", (float) converterDpi(rx), (float) converterDpi(ry),

--- a/ofdrw-converter/src/test/java/org/ofdrw/converter/export/LegacyPathExportTest.java
+++ b/ofdrw-converter/src/test/java/org/ofdrw/converter/export/LegacyPathExportTest.java
@@ -1,0 +1,103 @@
+package org.ofdrw.converter.export;
+
+import org.apache.pdfbox.contentstream.operator.Operator;
+import org.apache.pdfbox.cos.COSNumber;
+import org.apache.pdfbox.pdfparser.PDFStreamParser;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class LegacyPathExportTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void pdfBoxKeepsLegacyPathPositionAndLineWidth() throws Exception {
+        assertLegacyPath(new PDFExporterFactory() {
+            @Override
+            public OFDExporter create(Path ofd, Path pdf) throws IOException {
+                return new PDFExporterPDFBox(ofd, pdf);
+            }
+        }, "pdfbox");
+    }
+
+    @Test
+    void iTextKeepsLegacyPathPositionAndLineWidth() throws Exception {
+        assertLegacyPath(new PDFExporterFactory() {
+            @Override
+            public OFDExporter create(Path ofd, Path pdf) throws IOException {
+                return new PDFExporterIText(ofd, pdf);
+            }
+        }, "itext");
+    }
+
+    private void assertLegacyPath(PDFExporterFactory factory, String name) throws Exception {
+        Path ofd = tempDir.resolve(name + ".ofd");
+        Path pdf = tempDir.resolve(name + ".pdf");
+        createLegacyPathOFD(ofd);
+        try (OFDExporter exporter = factory.create(ofd, pdf)) {
+            exporter.export();
+        }
+
+        try (PDDocument document = PDDocument.load(pdf.toFile())) {
+            PDFStreamParser parser = new PDFStreamParser(document.getPage(0));
+            parser.parse();
+            List<Object> tokens = parser.getTokens();
+            assertEquals(1.35467d, operand(tokens, "w", 1, 0), 0.01d);
+            assertEquals(456d * 72d / 300d, operand(tokens, "m", 2, 0), 0.001d);
+            assertEquals(486d * 72d / 300d, operand(tokens, "l", 2, 0), 0.001d);
+        }
+    }
+
+    private static double operand(List<Object> tokens, String operator, int operandCount, int operandIndex) {
+        for (int i = 0; i < tokens.size(); i++) {
+            Object token = tokens.get(i);
+            if (token instanceof Operator && operator.equals(((Operator) token).getName())) {
+                return ((COSNumber) tokens.get(i - operandCount + operandIndex)).doubleValue();
+            }
+        }
+        throw new AssertionError("Missing PDF operator: " + operator);
+    }
+
+    private static void createLegacyPathOFD(Path output) throws IOException {
+        try (ZipOutputStream zip = new ZipOutputStream(java.nio.file.Files.newOutputStream(output))) {
+            put(zip, "OFD.xml", "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+                    + "<ofd:OFD xmlns:ofd=\"http://www.ofdspec.org\" Version=\"1.0\" DocType=\"OFD\">"
+                    + "<ofd:DocBody><ofd:DocInfo><ofd:DocID>legacy-path-test</ofd:DocID>"
+                    + "<ofd:Creator>Foxit OFD Creator</ofd:Creator></ofd:DocInfo>"
+                    + "<ofd:DocRoot>Doc_0/Document.xml</ofd:DocRoot></ofd:DocBody></ofd:OFD>");
+            put(zip, "Doc_0/Document.xml", "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+                    + "<ofd:Document xmlns:ofd=\"http://www.ofdspec.org\"><ofd:CommonData>"
+                    + "<ofd:PageArea><ofd:PhysicalBox>0 0 210 297</ofd:PhysicalBox></ofd:PageArea>"
+                    + "<ofd:MaxUnitID>3</ofd:MaxUnitID></ofd:CommonData><ofd:Pages>"
+                    + "<ofd:Page ID=\"1\" BaseLoc=\"Pages/Page_0/Content.xml\"/>"
+                    + "</ofd:Pages></ofd:Document>");
+            put(zip, "Doc_0/Pages/Page_0/Content.xml", "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+                    + "<ofd:Page xmlns:ofd=\"http://www.ofdspec.org\"><ofd:Content><ofd:Layer ID=\"2\">"
+                    + "<ofd:PathObject ID=\"3\" CTM=\"0.010948 0 0 0.010925 -6.688669 -5.418684\" "
+                    + "Boundary=\"38.438663 146.473328 2.963333 0.423333\" LineWidth=\"1.35467\" "
+                    + "Join=\"Round\" Cap=\"Round\"><ofd:AbbreviatedData>M 456 1732 L 486 1732"
+                    + "</ofd:AbbreviatedData></ofd:PathObject></ofd:Layer></ofd:Content></ofd:Page>");
+        }
+    }
+
+    private static void put(ZipOutputStream zip, String name, String content) throws IOException {
+        zip.putNextEntry(new ZipEntry(name));
+        zip.write(content.getBytes(StandardCharsets.UTF_8));
+        zip.closeEntry();
+    }
+
+    private interface PDFExporterFactory {
+        OFDExporter create(Path ofd, Path pdf) throws IOException;
+    }
+}

--- a/ofdrw-converter/src/test/java/org/ofdrw/converter/utils/PointUtilTest.java
+++ b/ofdrw-converter/src/test/java/org/ofdrw/converter/utils/PointUtilTest.java
@@ -1,6 +1,7 @@
 package org.ofdrw.converter.utils;
 
 import org.junit.jupiter.api.Test;
+import org.ofdrw.converter.point.PathPoint;
 import org.ofdrw.converter.point.TextCodePoint;
 import org.ofdrw.core.basicType.ST_Array;
 import org.ofdrw.core.basicType.ST_Box;
@@ -10,11 +11,15 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.ofdrw.converter.utils.CommonUtil.converterDpi;
 
 class PointUtilTest {
 
     private static final double EPSILON = 0.000001;
+    private static final double PAGE_WIDTH = 210d;
+    private static final double PAGE_HEIGHT = 297d;
 
     @Test
     void ctmTranslationShouldOnlyApplyToTextOrigin() {
@@ -52,5 +57,47 @@ class PointUtilTest {
         // Delta is a vector: only the CTM linear part applies, so (4, 5) -> (8, 15).
         assertEquals(converterDpi(120), points.get(1).getX(), EPSILON);
         assertEquals(converterDpi(1000 - 241), points.get(1).getY(), EPSILON);
+    }
+
+    @Test
+    void legacyFoxitPathUsesAbsolute300DpiCoordinates() {
+        ST_Box boundary = new ST_Box(38.438663, 146.473328, 2.963333, 0.423333);
+        ST_Array ctm = new ST_Array(0.010948, 0, 0, 0.010925, -6.688669, -5.418684);
+        List<PathPoint> source = PointUtil.convertPathAbbreviatedDatatoPoint("M 456 1732 L 486 1732");
+
+        assertTrue(PointUtil.isLegacyAbsolutePath(PAGE_WIDTH, PAGE_HEIGHT, boundary,
+                source, true, ctm));
+
+        List<PathPoint> result = PointUtil.calPdfPathPoint(PAGE_WIDTH, PAGE_HEIGHT, boundary,
+                source, true, ctm, null, null, true);
+        assertEquals(456d * 72d / 300d, result.get(0).x1, 0.001d);
+        assertEquals(486d * 72d / 300d, result.get(1).x1, 0.001d);
+        assertEquals((PAGE_HEIGHT - 1732d * 25.4d / 300d) * 72d / 25.4d,
+                result.get(0).y1, 0.001d);
+    }
+
+    @Test
+    void standardObjectSpacePathStillUsesBoundaryAndCtm() {
+        ST_Box boundary = new ST_Box(38, 146, 3, 1);
+        ST_Array ctm = new ST_Array(1, 0, 0, 1, 0, 0);
+        List<PathPoint> source = PointUtil.convertPathAbbreviatedDatatoPoint("M 0 0.5 L 3 0.5");
+
+        assertFalse(PointUtil.isLegacyAbsolutePath(PAGE_WIDTH, PAGE_HEIGHT, boundary,
+                source, true, ctm));
+
+        List<PathPoint> result = PointUtil.calPdfPathPoint(PAGE_WIDTH, PAGE_HEIGHT, boundary,
+                source, true, ctm, null, null, true);
+        assertEquals(38d * 72d / 25.4d, result.get(0).x1, 0.001d);
+        assertEquals((PAGE_HEIGHT - 146.5d) * 72d / 25.4d, result.get(0).y1, 0.001d);
+    }
+
+    @Test
+    void legacyFoxitLineWidthIsAlreadyInPdfPoints() {
+        ST_Array ctm = new ST_Array(0.010948, 0, 0, 0.010925, -6.688669, -5.418684);
+
+        assertEquals(1.35467d,
+                PointUtil.calPdfPathLineWidth(1.35467d, 1d, true, ctm), 0.00001d);
+        assertEquals(1.35467d * 72d / 25.4d * 0.010948d,
+                PointUtil.calPdfPathLineWidth(1.35467d, 1d, false, ctm), 0.00001d);
     }
 }


### PR DESCRIPTION
  ## 问题描述                                                                                                                                 
                                                                                                                                              
  部分由旧版 Foxit OFD Creator 生成的文档使用 300 DPI 设备坐标记录路径，                                                                      
  路径坐标并不是相对于 `PathObject Boundary` 的普通对象坐标。                                                                                 
                                                                                                                                              
  现有转换逻辑仍按照标准 OFD 路径处理，对坐标重复应用 `Boundary` 和 `CTM`，                                                                   
  导致转换为 PDF 后路径位置发生偏移。                                                                                                         
                                                                                                                                              
  如图所示，主要表现为：                                                                                            
                                                                                                                                              
  - 公式分数线位置偏移。                                                                                                                      
  - 根号等矢量路径位置异常。                                                                                                                  
  - PDFBox 导出时，部分较短的公式线段可能显示为圆点。                                                                                         
                                                                                                                                              
  该文档的创建器信息为 `Foxit OFD Creator 1.0`。                                                                                              
                                                                                                                                              
  ## 原因分析                                                                                                                                 
                                                                                                                                              
  旧版 Foxit 生成的部分路径具有以下特征：                                                                                                     
                                                                                                                                              
  - 路径坐标是基于 300 DPI 的页面绝对坐标。                                                                                                   
  - `PathObject` 同时声明了 `Boundary` 和 `CTM`。                                                                                             
  - 如果按照标准对象坐标应用 `Boundary` 和 `CTM`，转换后的路径会落在边界之外。                                                                
  - 将原始坐标按照 300 DPI 转换后，路径才会落在正确的页面位置。                                                                               
                                                                                                                                              
  此外，这类路径的线宽已经采用 PDF 点值。如果继续按照普通 OFD 毫米单位和                                                                      
  CTM 进行换算，会导致 PDFBox 中的短线宽度异常。                                                                                              
                                                                                                                                              
  ## 修改内容                                                                                                                                 
                                                                                                                                              
  - 增加旧版 Foxit 300 DPI 绝对路径的检测逻辑。                                                                                               
  - 对识别出的旧式路径直接按照 300 DPI 设备坐标转换。                                                                                         
  - 避免再次叠加 `Boundary` 和 `CTM`，修复路径位置偏移。                                                                                      
  - 统一 iText 和 PDFBox 的路径线宽处理。                                                                                                     
  - 对旧式路径保留原始 PDF 点线宽，避免短线被渲染为圆点。                                                                                     
  - 普通对象坐标路径继续使用原有转换逻辑。                                                                                                    
                                                                                                                                              
  ## 兼容性控制                                                                                                                               
                                                                                                                                              
  旧式路径兼容逻辑只在路径特征满足条件时启用，包括：                                                                                          
                                                                                                                                              
  - 路径不属于组合对象。                                                                                                                      
  - 路径包含有效的 `Boundary` 和 `CTM`。                                                                                                      
  - 原始坐标明显超出普通页面坐标范围。                                                                                                        
  - 按标准 CTM 转换后无法落入对象边界。                                                                                                       
  - 按照 300 DPI 解释后能够落入正确的页面区域。                                                                                               
                                                                                                                                              
  因此不会根据创建器名称直接修改整份文档的路径处理，也不会影响符合标准的                                                                      
  OFD 路径。                                                                                                                                  
                                                                                                                                              
  ## 测试                                                                                                                                     
                                                                                                                                              
  新增以下回归测试：                                                                                                                          
                                                                                                                                              
  - 验证旧版 Foxit 路径能够识别为 300 DPI 绝对坐标。                                                                                          
  - 验证普通对象空间路径仍使用原有的 `Boundary` 和 `CTM` 转换。                                                                               
  - 验证旧式路径线宽不会被重复换算。                                                                                                          
  - 分别使用 iText 和 PDFBox 导出最小化测试 OFD。                                                                                             
  - 解析导出后的 PDF 内容流，验证路径坐标和线宽。                                                                                             
                                                                                                                                              
  相关测试共 6 个，全部通过。     

 ## 其他说明

 本次修改使用了ChatGpt 5.6 sol 发现，并修改。                                                                                                            
                                                                                                                                              
  ## 修复效果                                                                                                                                 
                                                                                                                                              
  修复后，测试文档中的公式分数线、根号和短线可以在正确位置和宽度下显示，                                                              
  iText 与 PDFBox 两种导出方式均得到修复。

 ## 修复前

<img width="1349" height="753" alt="image" src="https://github.com/user-attachments/assets/8052bc8d-0c65-470a-b110-6896a8b2cd80" />
<img width="1070" height="629" alt="image" src="https://github.com/user-attachments/assets/bf00ccbb-0119-4b17-adef-dd2fc4d2f415" />

 ## 修复后

<img width="928" height="569" alt="image" src="https://github.com/user-attachments/assets/358812fe-a768-46e1-b04f-76262f0a5067" />
<img width="1002" height="557" alt="image" src="https://github.com/user-attachments/assets/48f22562-bd0b-40ca-b16a-429333ea8245" />
